### PR TITLE
[Fix] Revert back `__associated_rag_system` attribute.

### DIFF
--- a/examples/ra-dit/uv.lock
+++ b/examples/ra-dit/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "fed-rag"
-version = "0.0.5"
+version = "0.0.6.post1"
 source = { editable = "../../" }
 dependencies = [
     { name = "asyncio" },
@@ -1746,6 +1746,8 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/5b/76ca113a853b19c7b1da761f8a72cb6429b3bd0bf932537d8df4657f47c3/torchvision-0.21.0-1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ffa2a16499508fe6798323e455f312c7c55f2a88901c9a7c0fb1efa86cf7e327", size = 2329878 },
+    { url = "https://files.pythonhosted.org/packages/4e/fe/5e193353706dab96fe73ae100d5a633ff635ce310e0d92f3bc2958d075b1/torchvision-0.21.0-1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7e9e9afa150e40cd2a8f0701c43cb82a8d724f512896455c0918b987f94b84a4", size = 2280711 },
     { url = "https://files.pythonhosted.org/packages/6e/1b/28f527b22d5e8800184d0bc847f801ae92c7573a8c15979d92b7091c0751/torchvision-0.21.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:97a5814a93c793aaf0179cfc7f916024f4b63218929aee977b645633d074a49f", size = 1784140 },
     { url = "https://files.pythonhosted.org/packages/36/63/0722e153fd27d64d5b0af45b5c8cb0e80b35a68cf0130303bc9a8bb095c7/torchvision-0.21.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:b578bcad8a4083b40d34f689b19ca9f7c63e511758d806510ea03c29ac568f7b", size = 7238673 },
     { url = "https://files.pythonhosted.org/packages/bb/ea/03541ed901cdc30b934f897060d09bbf7a98466a08ad1680320f9ce0cbe0/torchvision-0.21.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5083a5b1fec2351bf5ea9900a741d54086db75baec4b1d21e39451e00977f1b1", size = 14701186 },

--- a/src/fed_rag/types/rag_system.py
+++ b/src/fed_rag/types/rag_system.py
@@ -39,21 +39,6 @@ class RAGSystem(BaseModel):
     knowledge_store: BaseKnowledgeStore
     rag_config: RAGConfig
 
-    def __init__(self, **kwargs: Any):
-        super().__init__(**kwargs)
-        # make rag system accessible to underlying models for generator/retriever
-        self.generator.model.__setattr__("__associated_rag_system", self)
-        if self.retriever.encoder:
-            self.retriever.encoder.__setattr__("__associated_rag_system", self)
-        if self.retriever.query_encoder:
-            self.retriever.query_encoder.__setattr__(
-                "__associated_rag_system", self
-            )
-        if self.retriever.context_encoder:
-            self.retriever.context_encoder.__setattr__(
-                "__associated_rag_system", self
-            )
-
     def query(self, query: str) -> RAGResponse:
         """Query the RAG system."""
         source_nodes = self.retrieve(query)

--- a/tests/rag_system/test_rag_system.py
+++ b/tests/rag_system/test_rag_system.py
@@ -30,8 +30,6 @@ def test_rag_system_init(
     assert rag_system.rag_config == rag_config
     assert rag_system.generator == mock_generator
     assert rag_system.retriever == mock_retriever
-    assert rag_system.generator.model.__associated_rag_system == rag_system
-    assert rag_system.retriever.encoder.__associated_rag_system == rag_system
 
 
 def test_rag_system_with_dual_encoder_init(
@@ -53,15 +51,6 @@ def test_rag_system_with_dual_encoder_init(
     assert rag_system.rag_config == rag_config
     assert rag_system.generator == mock_generator
     assert rag_system.retriever == mock_dual_retriever
-    assert rag_system.generator.model.__associated_rag_system == rag_system
-    assert (
-        rag_system.retriever.query_encoder.__associated_rag_system
-        == rag_system
-    )
-    assert (
-        rag_system.retriever.context_encoder.__associated_rag_system
-        == rag_system
-    )
 
 
 @patch.object(RAGSystem, "generate")


### PR DESCRIPTION
This breaks the lazy loading capabilities of Generator and Retriever. I think the better way to do this is through passing in a `Context` type in your trainer that maintains state in the train loop.