### PR TITLE
[Feature] Change knowledge stores to persist by `name`

### DIFF
--- a/src/fed_rag/base/knowledge_store.py
+++ b/src/fed_rag/base/knowledge_store.py
@@ -2,16 +2,21 @@
 
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel, ConfigDict
-from typing_extensions import Self
+from pydantic import BaseModel, ConfigDict, Field
 
 from fed_rag.types.knowledge_node import KnowledgeNode
+
+DEFAULT_KNOWLEDGE_STORE_NAME = "default"
 
 
 class BaseKnowledgeStore(BaseModel, ABC):
     """Base Knowledge Store Class."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+    name: str = Field(
+        description="Name of Knowledge Store used for caching and loading.",
+        default=DEFAULT_KNOWLEDGE_STORE_NAME,
+    )
 
     @abstractmethod
     def load_node(self, node: KnowledgeNode) -> None:
@@ -49,11 +54,10 @@ class BaseKnowledgeStore(BaseModel, ABC):
     def persist(self) -> None:
         """Save the KnowledgeStore nodes to a permanent storage."""
 
-    @classmethod
     @abstractmethod
-    def load(cls, ks_id: str) -> Self:
+    def load(self) -> None:
         """
-        Load the KnowledgeStore nodes from a permanent storage given an id.
+        Load the KnowledgeStore nodes from a permanent storage using `name`.
 
         Args:
             ks_id: The id of the knowledge store to load.

--- a/src/fed_rag/knowledge_stores/in_memory.py
+++ b/src/fed_rag/knowledge_stores/in_memory.py
@@ -9,10 +9,7 @@ import pyarrow.parquet as pq
 from pydantic import Field, PrivateAttr, model_serializer
 from typing_extensions import Self
 
-from fed_rag.base.knowledge_store import (
-    DEFAULT_KNOWLEDGE_STORE_NAME,
-    BaseKnowledgeStore,
-)
+from fed_rag.base.knowledge_store import BaseKnowledgeStore
 from fed_rag.exceptions.knowledge_stores import KnowledgeStoreNotFoundError
 from fed_rag.knowledge_stores.mixins import ManagedMixin
 from fed_rag.types.knowledge_node import KnowledgeNode
@@ -55,10 +52,8 @@ class InMemoryKnowledgeStore(BaseKnowledgeStore):
     _data: dict[str, KnowledgeNode] = PrivateAttr(default_factory=dict)
 
     @classmethod
-    def from_nodes(
-        cls, nodes: list[KnowledgeNode], name: str | None = None
-    ) -> Self:
-        instance = cls(name=name if name else DEFAULT_KNOWLEDGE_STORE_NAME)
+    def from_nodes(cls, nodes: list[KnowledgeNode], **kwargs: Any) -> Self:
+        instance = cls(**kwargs)
         instance.load_nodes(nodes)
         return instance
 

--- a/src/fed_rag/knowledge_stores/in_memory.py
+++ b/src/fed_rag/knowledge_stores/in_memory.py
@@ -143,7 +143,9 @@ class ManagedInMemoryKnowledgeStore(ManagedMixin, InMemoryKnowledgeStore):
 
         parquet_data = pq.read_table(filename).to_pylist()
         nodes = [KnowledgeNode(**data) for data in parquet_data]
-        knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(nodes)
+        knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+            nodes, name=name, default_cache_dir=cache_dir
+        )
         # set id
         knowledge_store.ks_id = ks_id
         return knowledge_store

--- a/src/fed_rag/knowledge_stores/in_memory.py
+++ b/src/fed_rag/knowledge_stores/in_memory.py
@@ -48,7 +48,7 @@ def _get_top_k_nodes(
 class InMemoryKnowledgeStore(BaseKnowledgeStore):
     """InMemoryKnowledgeStore Class."""
 
-    default_cache_dir: str = Field(default=DEFAULT_CACHE_DIR)
+    cache_dir: str = Field(default=DEFAULT_CACHE_DIR)
     _data: dict[str, KnowledgeNode] = PrivateAttr(default_factory=dict)
 
     @classmethod
@@ -103,12 +103,12 @@ class InMemoryKnowledgeStore(BaseKnowledgeStore):
 
         parquet_table = pa.Table.from_pylist(data_values)
 
-        filename = Path(self.default_cache_dir) / f"{self.name}.parquet"
+        filename = Path(self.cache_dir) / f"{self.name}.parquet"
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(parquet_table, filename)
 
     def load(self) -> None:
-        filename = Path(self.default_cache_dir) / f"{self.name}.parquet"
+        filename = Path(self.cache_dir) / f"{self.name}.parquet"
         if not filename.exists():
             msg = f"Knowledge store '{self.name}' not found at expected location: {filename}"
             raise KnowledgeStoreNotFoundError(msg)
@@ -125,9 +125,7 @@ class ManagedInMemoryKnowledgeStore(ManagedMixin, InMemoryKnowledgeStore):
 
         parquet_table = pa.Table.from_pylist(data_values)
 
-        filename = (
-            Path(self.default_cache_dir) / self.name / f"{self.ks_id}.parquet"
-        )
+        filename = Path(self.cache_dir) / self.name / f"{self.ks_id}.parquet"
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(parquet_table, filename)
 
@@ -144,7 +142,7 @@ class ManagedInMemoryKnowledgeStore(ManagedMixin, InMemoryKnowledgeStore):
         parquet_data = pq.read_table(filename).to_pylist()
         nodes = [KnowledgeNode(**data) for data in parquet_data]
         knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
-            nodes, name=name, default_cache_dir=cache_dir
+            nodes, name=name, cache_dir=cache_dir
         )
         # set id
         knowledge_store.ks_id = ks_id

--- a/src/fed_rag/knowledge_stores/in_memory.py
+++ b/src/fed_rag/knowledge_stores/in_memory.py
@@ -48,7 +48,7 @@ def _get_top_k_nodes(
 class InMemoryKnowledgeStore(BaseKnowledgeStore):
     """InMemoryKnowledgeStore Class."""
 
-    default_save_path: str = Field(default=DEFAULT_CACHE_DIR)
+    default_cache_dir: str = Field(default=DEFAULT_CACHE_DIR)
     _data: dict[str, KnowledgeNode] = PrivateAttr(default_factory=dict)
 
     @classmethod
@@ -103,12 +103,12 @@ class InMemoryKnowledgeStore(BaseKnowledgeStore):
 
         parquet_table = pa.Table.from_pylist(data_values)
 
-        filename = Path(self.default_save_path) / f"{self.name}.parquet"
+        filename = Path(self.default_cache_dir) / f"{self.name}.parquet"
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(parquet_table, filename)
 
     def load(self) -> None:
-        filename = Path(self.default_save_path) / f"{self.name}.parquet"
+        filename = Path(self.default_cache_dir) / f"{self.name}.parquet"
         if not filename.exists():
             msg = f"Knowledge store '{self.name}' not found at expected location: {filename}"
             raise KnowledgeStoreNotFoundError(msg)
@@ -126,7 +126,7 @@ class ManagedInMemoryKnowledgeStore(ManagedMixin, InMemoryKnowledgeStore):
         parquet_table = pa.Table.from_pylist(data_values)
 
         filename = (
-            Path(self.default_save_path) / self.name / f"{self.ks_id}.parquet"
+            Path(self.default_cache_dir) / self.name / f"{self.ks_id}.parquet"
         )
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(parquet_table, filename)

--- a/src/fed_rag/knowledge_stores/mixins.py
+++ b/src/fed_rag/knowledge_stores/mixins.py
@@ -1,7 +1,18 @@
 import uuid
+from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
+from typing_extensions import Self
 
 
-class ManagedMixin(BaseModel):
-    ks_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+def generate_ks_id() -> str:
+    return str(uuid.uuid4())
+
+
+class ManagedMixin(BaseModel, ABC):
+    ks_id: str = Field(default_factory=generate_ks_id)
+
+    @classmethod
+    @abstractmethod
+    def from_name_and_id(cls, ks_id: str) -> Self:
+        """Load a managed Knowledge Store by id."""

--- a/src/fed_rag/knowledge_stores/mixins.py
+++ b/src/fed_rag/knowledge_stores/mixins.py
@@ -1,0 +1,7 @@
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class ManagedMixin(BaseModel):
+    ks_id: str = Field(default_factory=lambda: str(uuid.uuid4()))

--- a/tests/knowledge_stores/test_in_memory.py
+++ b/tests/knowledge_stores/test_in_memory.py
@@ -130,7 +130,7 @@ def test_retrieve(
 def test_persist(text_nodes: list[KnowledgeNode]) -> None:
     with tempfile.TemporaryDirectory() as dirpath:
         knowledge_store = InMemoryKnowledgeStore.from_nodes(nodes=text_nodes)
-        knowledge_store.default_save_path = dirpath
+        knowledge_store.default_cache_dir = dirpath
         knowledge_store.persist()
 
         filename = Path(dirpath) / f"{knowledge_store.name}.parquet"
@@ -140,13 +140,13 @@ def test_persist(text_nodes: list[KnowledgeNode]) -> None:
 def test_load(text_nodes: list[KnowledgeNode]) -> None:
     with tempfile.TemporaryDirectory() as dirpath:
         knowledge_store = InMemoryKnowledgeStore.from_nodes(
-            nodes=text_nodes, name="test_ks", default_save_path=dirpath
+            nodes=text_nodes, name="test_ks", default_cache_dir=dirpath
         )
         knowledge_store.persist()
 
         # load into new empty instance
         loaded_knowledge_store = InMemoryKnowledgeStore(
-            name="test_ks", default_save_path=dirpath
+            name="test_ks", default_cache_dir=dirpath
         )
         loaded_knowledge_store.load()
 
@@ -156,7 +156,7 @@ def test_load(text_nodes: list[KnowledgeNode]) -> None:
 def test_persist_overwrite(text_nodes: list[KnowledgeNode]) -> None:
     with tempfile.TemporaryDirectory() as dirpath:
         knowledge_store = InMemoryKnowledgeStore.from_nodes(
-            nodes=text_nodes, name="test_ks", default_save_path=dirpath
+            nodes=text_nodes, name="test_ks", default_cache_dir=dirpath
         )
         knowledge_store.persist()
 
@@ -173,7 +173,7 @@ def test_persist_overwrite(text_nodes: list[KnowledgeNode]) -> None:
 
         # load into new empty instance
         loaded_knowledge_store = InMemoryKnowledgeStore(
-            name="test_ks", default_save_path=dirpath
+            name="test_ks", default_cache_dir=dirpath
         )
         loaded_knowledge_store.load()
 

--- a/tests/knowledge_stores/test_in_memory_managed.py
+++ b/tests/knowledge_stores/test_in_memory_managed.py
@@ -143,7 +143,7 @@ def test_persist(text_nodes: list[KnowledgeNode]) -> None:
         knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
             nodes=text_nodes
         )
-        knowledge_store.default_save_path = dirpath
+        knowledge_store.default_cache_dir = dirpath
         knowledge_store.persist()
 
         filename = (
@@ -161,7 +161,7 @@ def test_load(mock_uuid: MagicMock, text_nodes: list[KnowledgeNode]) -> None:
         knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
             nodes=text_nodes, name="test_ks"
         )
-        knowledge_store.default_save_path = dirpath
+        knowledge_store.default_cache_dir = dirpath
         knowledge_store.persist()
 
         loaded_knowledge_store = (
@@ -184,7 +184,7 @@ def test_persist_overwrite(
         knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
             nodes=text_nodes, name="test_ks"
         )
-        knowledge_store.default_save_path = dirpath
+        knowledge_store.default_cache_dir = dirpath
         knowledge_store.persist()
 
         knowledge_store.load_node(

--- a/tests/knowledge_stores/test_in_memory_managed.py
+++ b/tests/knowledge_stores/test_in_memory_managed.py
@@ -1,0 +1,205 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fed_rag.base.knowledge_store import BaseKnowledgeStore
+from fed_rag.knowledge_stores.in_memory import ManagedInMemoryKnowledgeStore
+from fed_rag.types.knowledge_node import KnowledgeNode
+
+
+@pytest.fixture
+def text_nodes() -> list[KnowledgeNode]:
+    return [
+        KnowledgeNode(
+            embedding=[1.0, 0.0, 1.0],
+            node_type="text",
+            text_content="node 1",
+            metadata={"key1": "value1"},
+        ),
+        KnowledgeNode(
+            embedding=[1.0, 0.0, 0.0],
+            node_type="text",
+            text_content="node 2",
+            metadata={"key2": "value2"},
+        ),
+        KnowledgeNode(
+            embedding=[1.0, 1.0, 0.0],
+            node_type="text",
+            text_content="node 3",
+            metadata={"key3": "value3"},
+        ),
+    ]
+
+
+def test_in_memory_knowledge_store_class() -> None:
+    names_of_base_classes = [
+        b.__name__ for b in ManagedInMemoryKnowledgeStore.__mro__
+    ]
+    assert BaseKnowledgeStore.__name__ in names_of_base_classes
+
+
+def test_in_memory_knowledge_store_init() -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore()
+
+    assert knowledge_store.count == 0
+
+
+def test_from_nodes(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+        nodes=text_nodes
+    )
+
+    assert knowledge_store.count == 3
+    assert all(n.node_id in knowledge_store._data for n in text_nodes)
+
+
+def test_delete_node(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+        nodes=text_nodes
+    )
+
+    assert knowledge_store.count == 3
+
+    res = knowledge_store.delete_node(text_nodes[0].node_id)
+
+    assert res is True
+    assert knowledge_store.count == 2
+    assert text_nodes[0].node_id not in knowledge_store._data
+
+
+def test_delete_node_returns_false(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+        nodes=text_nodes
+    )
+
+    assert knowledge_store.count == 3
+
+    res = knowledge_store.delete_node("non_included_id")
+
+    assert res is False
+    assert knowledge_store.count == 3
+    assert all(n.node_id in knowledge_store._data for n in text_nodes)
+
+
+def test_load_node(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore()
+    assert knowledge_store.count == 0
+
+    knowledge_store.load_node(text_nodes[-1])
+
+    assert knowledge_store.count == 1
+    assert text_nodes[-1].node_id in knowledge_store._data
+
+
+def test_load_nodes(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore()
+    assert knowledge_store.count == 0
+
+    knowledge_store.load_nodes(text_nodes)
+
+    assert knowledge_store.count == 3
+    assert all(n.node_id in knowledge_store._data for n in text_nodes)
+
+
+def test_clear(text_nodes: list[KnowledgeNode]) -> None:
+    knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+        nodes=text_nodes
+    )
+    assert knowledge_store.count == 3
+
+    knowledge_store.clear()
+
+    assert knowledge_store.count == 0
+    assert all(n.node_id not in knowledge_store._data for n in text_nodes)
+
+
+@pytest.mark.parametrize(
+    ("query_emb", "top_k", "expected_node_ix"),
+    [([1.0, 1.0, 1.0], 2, [0, 2]), ([0.5, 0.0, 0.0], 1, [1])],
+    ids=[str([1.0, 1.0, 1.0]), str([0.5, 0.0, 0.0])],
+)
+def test_retrieve(
+    query_emb: list[float],
+    top_k: int,
+    expected_node_ix: list[int],
+    text_nodes: list[KnowledgeNode],
+) -> None:
+    # arrange
+    knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+        nodes=text_nodes
+    )
+
+    # act
+    res = knowledge_store.retrieve(query_emb, top_k=top_k)
+
+    # assert
+    assert [el[1] for el in res] == [text_nodes[ix] for ix in expected_node_ix]
+
+
+def test_persist(text_nodes: list[KnowledgeNode]) -> None:
+    with tempfile.TemporaryDirectory() as dirpath:
+        knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+            nodes=text_nodes
+        )
+        knowledge_store.default_save_path = dirpath
+        knowledge_store.persist()
+
+        filename = (
+            Path(dirpath)
+            / knowledge_store.name
+            / f"{knowledge_store.ks_id}.parquet"
+        )
+        assert filename.exists()
+
+
+@patch("fed_rag.knowledge_stores.mixins.uuid")
+def test_load(mock_uuid: MagicMock, text_nodes: list[KnowledgeNode]) -> None:
+    mock_uuid.uuid4.return_value = "test_ks_id"
+    with tempfile.TemporaryDirectory() as dirpath:
+        knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+            nodes=text_nodes, name="test_ks"
+        )
+        knowledge_store.default_save_path = dirpath
+        knowledge_store.persist()
+
+        loaded_knowledge_store = (
+            ManagedInMemoryKnowledgeStore.from_name_and_id(
+                name="test_ks", ks_id="test_ks_id", cache_dir=dirpath
+            )
+        )
+
+        assert loaded_knowledge_store.ks_id == knowledge_store.ks_id
+        assert loaded_knowledge_store._data == knowledge_store._data
+
+
+@patch("fed_rag.knowledge_stores.mixins.uuid")
+def test_persist_overwrite(
+    mock_uuid: MagicMock,
+    text_nodes: list[KnowledgeNode],
+) -> None:
+    mock_uuid.uuid4.return_value = "test_ks_id"
+    with tempfile.TemporaryDirectory() as dirpath:
+        knowledge_store = ManagedInMemoryKnowledgeStore.from_nodes(
+            nodes=text_nodes, name="test_ks"
+        )
+        knowledge_store.default_save_path = dirpath
+        knowledge_store.persist()
+
+        knowledge_store.load_node(
+            KnowledgeNode(
+                embedding=[1.0, 1.0, 1.0],
+                node_type="text",
+                text_content="node 4",
+                metadata={"key4": "value4"},
+            )
+        )
+        knowledge_store.persist()
+
+        loaded_knowledge_store = (
+            ManagedInMemoryKnowledgeStore.from_name_and_id(
+                name="test_ks", ks_id="test_ks_id", cache_dir=dirpath
+            )
+        )
+        assert loaded_knowledge_store._data == knowledge_store._data

--- a/tests/knowledge_stores/test_in_memory_managed.py
+++ b/tests/knowledge_stores/test_in_memory_managed.py
@@ -175,14 +175,12 @@ def test_load(mock_uuid: MagicMock, text_nodes: list[KnowledgeNode]) -> None:
         assert loaded_knowledge_store._data == knowledge_store._data
 
 
-@patch("fed_rag.knowledge_stores.mixins.uuid")
-def test_load_with_missing_file_raises_error(mock_uuid: MagicMock) -> None:
-    mock_uuid.uuid4.return_value = "test_ks_id"
+def test_load_with_missing_file_raises_error() -> None:
     with tempfile.TemporaryDirectory() as dirpath:
-        knowledge_store = ManagedInMemoryKnowledgeStore(cache_dir=dirpath)
-
         with pytest.raises(KnowledgeStoreNotFoundError):
-            knowledge_store.load()
+            ManagedInMemoryKnowledgeStore.from_name_and_id(
+                name="test_ks", ks_id="test_ks_id", cache_dir=dirpath
+            )
 
 
 @patch("fed_rag.knowledge_stores.mixins.uuid")


### PR DESCRIPTION
# Description

After working with the persist/load methods, I found myself not needing a `ks_id` but rather wanting to save by a name. This is kind of similar to how HuggingFace loads and saves by name. I think this path is likely the more common one for our general users, however, I think that the `ks_id` will be useful if this was ever to become managed and we want to maintain a bunch of these distinguished by `name` and `ks_id`.

Thus, in this PR, I've made some changes to `persist` and `load` for `InMemoryKnowledgeStore` that feels a bit more natural and simple/intuitive for the general user. I didn't throw away the business of loading and persisting by `ks_id`, but rather I created a new class `ManagedInMemoryKnowledgeStore` where I think the use of `ks_id` would be more relevant.

## In summary

### Bigger Changes
- Made persisting and loading with `InMemoryKnowledgeStore` done via `name` which is a newly added attribute to `BaseKnowledgeStore` class.
- Added `~knowledge_store.mixins.ManagedMixin` which includes a `ks_id` attribute and an abstract class method `from_name_and_id` that subclasses must implement
- Added `ManagedInMemoryKnowledgeStore` that inherits from the `InMemoryKnowledgeStore` and `ManagedMixin` — this class persists and loads by `ks_id`.

### Smaller Changes
- Changed `default_save_path` to a instance attribute called `cache_dir` (setting a DEFAULT_CACHE_DIR that this resolves to by default — made it easier to work with)
- Used `tempfile.tempdir` in pytests so we don't have to do manual cleanups
