### PR TITLE
[Feature] Add abstract method `BaseGenerator.compute_target_sequence_proba` (cherry picked)

### DIFF
--- a/examples/ra-dit/ra_dit/generators/llama2_7b.py
+++ b/examples/ra-dit/ra_dit/generators/llama2_7b.py
@@ -76,3 +76,10 @@ if __name__ == "__main__":
         query="Tell me a funny joke.", context="I find math very funny."
     )
     print(response)
+
+    # target proba
+    prompt = "The capital of France is"
+    target = " Toronto"  # Note the space at the beginning
+
+    probability = generator.compute_target_sequence_proba(prompt, target)
+    print(f"Probability of '{target}' given '{prompt}': {probability:.6f}")

--- a/src/fed_rag/base/generator.py
+++ b/src/fed_rag/base/generator.py
@@ -26,3 +26,10 @@ class BaseGenerator(BaseModel, ABC):
     @abstractmethod
     def tokenizer(self) -> BaseTokenizer:
         """Tokenizer associated with this generator."""
+
+    @abstractmethod
+    def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
+        """Compute P(target | prompt).
+
+        NOTE: this is used in LM Supervised Retriever fine-tuning.
+        """

--- a/src/fed_rag/base/generator.py
+++ b/src/fed_rag/base/generator.py
@@ -28,7 +28,9 @@ class BaseGenerator(BaseModel, ABC):
         """Tokenizer associated with this generator."""
 
     @abstractmethod
-    def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
+    def compute_target_sequence_proba(
+        self, prompt: str, target: str
+    ) -> torch.Tensor:
         """Compute P(target | prompt).
 
         NOTE: this is used in LM Supervised Retriever fine-tuning.

--- a/src/fed_rag/generators/hf_peft_model.py
+++ b/src/fed_rag/generators/hf_peft_model.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+import torch.nn.functional as F
 from pydantic import ConfigDict, Field, PrivateAttr
 
 try:
@@ -167,3 +168,53 @@ class HFPeftModelGenerator(BaseGenerator):
             generated_ids, skip_special_tokens=True
         )
         return outputs[0]
+
+    def compute_target_sequence_proba(
+        self, prompt: str, target: str
+    ) -> torch.Tensor:
+        """Computes the target sequence probability given the prompt.
+
+        Args:
+            generator (BaseGenerator): The generator LLM
+            prompt (str): The input i.e. conditional prompt sequence
+            target (str): The target sequence
+
+        Returns:
+            proba (torch.Tensor): The probability of target sequence given a prompt.
+                i.e., P_{LLM}(target | sequence)
+        """
+        # get model
+        model = self.model
+        tokenizer = self.tokenizer
+
+        # Combine prompt and target for teacher forcing
+        input_text = prompt + target
+        encode_result = tokenizer.encode(input_text)
+        input_ids = encode_result["input_ids"]
+
+        # Get the token IDs for just the target portion
+        prompt_only_encode_result = tokenizer.encode(prompt)
+        target_start_idx = len(prompt_only_encode_result["input_ids"])
+        target_ids = input_ids[target_start_idx:]
+
+        # Get the logits from the model
+        with torch.no_grad():
+            outputs = model(torch.tensor(input_ids).unsqueeze(0))
+            logits = outputs.logits
+
+        # Calculate probability of each target token given the previous tokens
+        log_probs = []
+        for i, target_id in enumerate(target_ids):
+            # get log prob of next target token in the sequence
+            next_token_pos = target_start_idx + i - 1
+            next_token_logits = logits[0, next_token_pos, :]
+            probs = F.softmax(next_token_logits, dim=-1)
+            log_prob = torch.log(probs[target_id]).item()
+            log_probs.append(log_prob)
+
+        # Sum log probabilities to get sequence log probability
+        sequence_log_prob = sum(log_probs)
+        # Convert to probability
+        sequence_prob = torch.exp(torch.tensor(sequence_log_prob)).item()
+
+        return sequence_prob

--- a/src/fed_rag/generators/hf_peft_model.py
+++ b/src/fed_rag/generators/hf_peft_model.py
@@ -206,7 +206,7 @@ class HFPeftModelGenerator(BaseGenerator):
         log_probs = []
         for i, target_id in enumerate(target_ids):
             # get log prob of next target token in the sequence
-            next_token_pos = target_start_idx + i - 1
+            next_token_pos = target_start_idx + i
             next_token_logits = logits[0, next_token_pos, :]
             probs = F.softmax(next_token_logits, dim=-1)
             log_prob = torch.log(probs[target_id]).item()

--- a/src/fed_rag/generators/hf_peft_model.py
+++ b/src/fed_rag/generators/hf_peft_model.py
@@ -215,6 +215,6 @@ class HFPeftModelGenerator(BaseGenerator):
         # Sum log probabilities to get sequence log probability
         sequence_log_prob = sum(log_probs)
         # Convert to probability
-        sequence_prob = torch.exp(torch.tensor(sequence_log_prob)).item()
+        sequence_prob = torch.exp(torch.tensor(sequence_log_prob))
 
         return sequence_prob

--- a/src/fed_rag/generators/hf_pretrained_model.py
+++ b/src/fed_rag/generators/hf_pretrained_model.py
@@ -114,6 +114,10 @@ class HFPretrainedModelGenerator(BaseGenerator):
     def tokenizer(self) -> HFPretrainedTokenizer:
         return self._tokenizer
 
+    @tokenizer.setter
+    def tokenizer(self, value: HFPretrainedTokenizer) -> None:
+        self._tokenizer = value
+
     # generate
     def generate(self, query: str, context: str, **kwargs: Any) -> str:
         formatted_query = self.prompt_template.format(
@@ -155,23 +159,19 @@ class HFPretrainedModelGenerator(BaseGenerator):
             proba (torch.Tensor): The probability of target sequence given a prompt.
                 i.e., P_{LLM}(target | sequence)
         """
-        # get model
-        model = self.model
-        tokenizer = self.tokenizer
-
         # Combine prompt and target for teacher forcing
         input_text = prompt + target
-        encode_result = tokenizer.encode(input_text)
+        encode_result = self.tokenizer.encode(input_text)
         input_ids = encode_result["input_ids"]
 
         # Get the token IDs for just the target portion
-        prompt_only_encode_result = tokenizer.encode(prompt)
+        prompt_only_encode_result = self.tokenizer.encode(prompt)
         target_start_idx = len(prompt_only_encode_result["input_ids"])
         target_ids = input_ids[target_start_idx:]
 
         # Get the logits from the model
         with torch.no_grad():
-            outputs = model(torch.tensor(input_ids).unsqueeze(0))
+            outputs = self.model(torch.tensor(input_ids).unsqueeze(0))
             logits = outputs.logits
 
         # Calculate probability of each target token given the previous tokens
@@ -187,6 +187,6 @@ class HFPretrainedModelGenerator(BaseGenerator):
         # Sum log probabilities to get sequence log probability
         sequence_log_prob = sum(log_probs)
         # Convert to probability
-        sequence_prob = torch.exp(torch.tensor(sequence_log_prob)).item()
+        sequence_prob = torch.exp(torch.tensor(sequence_log_prob))
 
         return sequence_prob

--- a/src/fed_rag/generators/hf_pretrained_model.py
+++ b/src/fed_rag/generators/hf_pretrained_model.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+import torch.nn.functional as F
 from pydantic import ConfigDict, Field, PrivateAttr
 
 try:
@@ -139,3 +140,53 @@ class HFPretrainedModelGenerator(BaseGenerator):
             generated_ids, skip_special_tokens=True
         )
         return outputs[0]
+
+    def compute_target_sequence_proba(
+        self, prompt: str, target: str
+    ) -> torch.Tensor:
+        """Computes the target sequence probability given the prompt.
+
+        Args:
+            generator (BaseGenerator): The generator LLM
+            prompt (str): The input i.e. conditional prompt sequence
+            target (str): The target sequence
+
+        Returns:
+            proba (torch.Tensor): The probability of target sequence given a prompt.
+                i.e., P_{LLM}(target | sequence)
+        """
+        # get model
+        model = self.model
+        tokenizer = self.tokenizer
+
+        # Combine prompt and target for teacher forcing
+        input_text = prompt + target
+        encode_result = tokenizer.encode(input_text)
+        input_ids = encode_result["input_ids"]
+
+        # Get the token IDs for just the target portion
+        prompt_only_encode_result = tokenizer.encode(prompt)
+        target_start_idx = len(prompt_only_encode_result["input_ids"])
+        target_ids = input_ids[target_start_idx:]
+
+        # Get the logits from the model
+        with torch.no_grad():
+            outputs = model(torch.tensor(input_ids).unsqueeze(0))
+            logits = outputs.logits
+
+        # Calculate probability of each target token given the previous tokens
+        log_probs = []
+        for i, target_id in enumerate(target_ids):
+            # get log prob of next target token in the sequence
+            next_token_pos = target_start_idx + i - 1
+            next_token_logits = logits[0, next_token_pos, :]
+            probs = F.softmax(next_token_logits, dim=-1)
+            log_prob = torch.log(probs[target_id]).item()
+            log_probs.append(log_prob)
+
+        # Sum log probabilities to get sequence log probability
+        sequence_log_prob = sum(log_probs)
+        # Convert to probability
+        sequence_prob = torch.exp(torch.tensor(sequence_log_prob)).item()
+
+        return sequence_prob

--- a/src/fed_rag/generators/hf_pretrained_model.py
+++ b/src/fed_rag/generators/hf_pretrained_model.py
@@ -178,7 +178,7 @@ class HFPretrainedModelGenerator(BaseGenerator):
         log_probs = []
         for i, target_id in enumerate(target_ids):
             # get log prob of next target token in the sequence
-            next_token_pos = target_start_idx + i - 1
+            next_token_pos = target_start_idx + i
             next_token_logits = logits[0, next_token_pos, :]
             probs = F.softmax(next_token_logits, dim=-1)
             log_prob = torch.log(probs[target_id]).item()

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -111,6 +111,9 @@ class MockGenerator(BaseGenerator):
     def generate(self, input: str) -> str:
         return f"mock output from '{input}'."
 
+    def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
+        return 0.42
+
     @property
     def model(self) -> torch.nn.Module:
         return self._model

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -4,3 +4,10 @@ from fed_rag.base.generator import BaseGenerator
 def test_generate(mock_generator: BaseGenerator) -> None:
     output = mock_generator.generate("hello")
     assert output == "mock output from 'hello'."
+
+
+def test_compute_target_sequence_proba(mock_generator: BaseGenerator) -> None:
+    proba = mock_generator.compute_target_sequence_proba(
+        prompt="mock prompt", target="mock target"
+    )
+    assert proba == 0.42

--- a/tests/generators/test_hf_peft.py
+++ b/tests/generators/test_hf_peft.py
@@ -192,6 +192,28 @@ def test_generate() -> None:
     mock_model.generate.assert_called_once()
 
 
+def test_compute_target_seequence_proba() -> None:
+    # arrange
+    generator = HFPeftModelGenerator(
+        model_name="fake_name",
+        base_model_name="fake_base_name",
+        load_model_at_init=False,
+    )
+    mock_tokenizer = MagicMock()
+    mock_model = MagicMock()
+    generator.model = mock_model
+    generator.tokenizer = mock_tokenizer
+
+    # act
+    _ = generator.compute_target_sequence_proba(
+        prompt="fake prompt", target=" fake target"
+    )
+
+    mock_tokenizer.encode.assert_any_call("fake prompt fake target")
+    mock_tokenizer.encode.assert_any_call("fake prompt")
+    mock_model.assert_called_once()
+
+
 def test_huggingface_extra_missing() -> None:
     """Test extra is not installed."""
 

--- a/tests/generators/test_hf_peft.py
+++ b/tests/generators/test_hf_peft.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from peft import PeftModel
+from torch.testing import assert_close
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -13,6 +14,7 @@ from transformers import (
 )
 
 from fed_rag.base.generator import BaseGenerator
+from fed_rag.base.tokenizer import EncodeResult
 from fed_rag.generators.hf_peft_model import HFPeftModelGenerator
 from fed_rag.tokenizers.hf_pretrained_tokenizer import HFPretrainedTokenizer
 
@@ -192,7 +194,10 @@ def test_generate() -> None:
     mock_model.generate.assert_called_once()
 
 
-def test_compute_target_seequence_proba() -> None:
+@patch("fed_rag.generators.hf_peft_model.F")
+def test_compute_target_sequence_proba(
+    mock_torch_functional: MagicMock,
+) -> None:
     # arrange
     generator = HFPeftModelGenerator(
         model_name="fake_name",
@@ -200,18 +205,27 @@ def test_compute_target_seequence_proba() -> None:
         load_model_at_init=False,
     )
     mock_tokenizer = MagicMock()
+    mock_tokenizer.encode.side_effect = [
+        EncodeResult(input_ids=[0, 1, 2, 3, 4]),
+        EncodeResult(input_ids=[0, 1, 2]),
+    ]
+    mock_torch_functional.softmax.return_value = torch.tensor(
+        [0.2, 0.2, 0.2, 0.2, 0.2]
+    )
     mock_model = MagicMock()
     generator.model = mock_model
     generator.tokenizer = mock_tokenizer
 
     # act
-    _ = generator.compute_target_sequence_proba(
+    result = generator.compute_target_sequence_proba(
         prompt="fake prompt", target=" fake target"
     )
 
     mock_tokenizer.encode.assert_any_call("fake prompt fake target")
     mock_tokenizer.encode.assert_any_call("fake prompt")
+    assert mock_torch_functional.softmax.call_count == 2
     mock_model.assert_called_once()
+    assert_close(result, torch.tensor(0.2**2))
 
 
 def test_huggingface_extra_missing() -> None:

--- a/tests/rag_system/conftest.py
+++ b/tests/rag_system/conftest.py
@@ -124,6 +124,9 @@ class MockGenerator(BaseGenerator):
     def generate(self, input: str) -> str:
         return f"mock output from '{input}'."
 
+    def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
+        return 0.42
+
     @property
     def model(self) -> torch.nn.Module:
         return self._model


### PR DESCRIPTION
This method is required for being able to perform LM Supervised Fine-tuning of Retriever models in a RAG System.

Decided to make a class method for better encapsulation, ease of maintenance/testing and implementation flexibility.

NOTE:
- this is not very dry, so in a subsequent PR we're going to tidy this up to reduce duplicated code for `hf_peft_model` and `hf_pretrained_model`.