### PR TITLE
[Feature] Add `PyTorchTrainerMixin`

### DIFF
--- a/src/fed_rag/exceptions/__init__.py
+++ b/src/fed_rag/exceptions/__init__.py
@@ -19,6 +19,7 @@ from .inspectors import (
 )
 from .knowledge_stores import KnowledgeStoreError, KnowledgeStoreNotFoundError
 from .trainer import (
+    InconsistentDatasetError,
     InvalidDataCollatorError,
     InvalidLossError,
     MissingInputTensor,
@@ -66,4 +67,5 @@ __all__ = [
     "InvalidLossError",
     "MissingInputTensor",
     "InvalidDataCollatorError",
+    "InconsistentDatasetError",
 ]

--- a/src/fed_rag/exceptions/trainer.py
+++ b/src/fed_rag/exceptions/trainer.py
@@ -7,6 +7,10 @@ class TrainerError(FedRAGError):
     pass
 
 
+class InconsistentDatasetError(TrainerError):
+    pass
+
+
 class InvalidLossError(TrainerError):
     pass
 

--- a/src/fed_rag/trainers/pytorch/__init__.py
+++ b/src/fed_rag/trainers/pytorch/__init__.py
@@ -1,0 +1,4 @@
+from .mixin import PyTorchTrainerMixin, PyTorchTrainerProtocol
+from .training_args import TrainingArgs
+
+__all__ = ["TrainingArgs", "PyTorchTrainerMixin", "PyTorchTrainerProtocol"]

--- a/src/fed_rag/trainers/pytorch/mixin.py
+++ b/src/fed_rag/trainers/pytorch/mixin.py
@@ -1,0 +1,58 @@
+"""PyTorch Trainer Mixin"""
+
+from abc import ABC
+from typing import Any, Protocol, runtime_checkable
+
+import torch.nn as nn
+from pydantic import BaseModel, ConfigDict
+from torch.utils.data import DataLoader, Dataset
+
+from fed_rag.exceptions import InconsistentDatasetError
+
+from .training_args import TrainingArgs
+
+
+# Define the protocol for runtime checking
+@runtime_checkable
+class PyTorchTrainerProtocol(Protocol):
+    train_dataset: Dataset
+    training_arguments: TrainingArgs | None
+    train_dataloader: DataLoader
+
+    def model(self) -> nn.Module:
+        pass  # pragma: no cover
+
+
+class PyTorchTrainerMixin(BaseModel, ABC):
+    """HuggingFace Trainer Mixin."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
+    train_dataset: Dataset
+    train_dataloader: DataLoader
+    training_arguments: TrainingArgs | None = None
+
+    def __init__(
+        self,
+        train_dataloader: DataLoader,
+        train_dataset: Dataset | None = None,
+        training_arguments: TrainingArgs | None = None,
+        **kwargs: Any,
+    ):
+        if train_dataset is None:
+            train_dataset = train_dataloader.dataset
+        else:
+            # ensure consistency between loader.dataset and the supplied one
+            if id(train_dataset) != id(train_dataloader.dataset):
+                raise InconsistentDatasetError(
+                    "Inconsistent datasets detected between supplied `train_dataset` and that "
+                    "associated with the `train_dataloader`. These two datasets must be the same."
+                )
+
+        super().__init__(
+            train_dataset=train_dataset,
+            train_dataloader=train_dataloader,
+            training_arguments=training_arguments,
+            **kwargs,
+        )

--- a/src/fed_rag/trainers/pytorch/training_args.py
+++ b/src/fed_rag/trainers/pytorch/training_args.py
@@ -1,0 +1,16 @@
+"""Training Args"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TrainingArgs(BaseModel):
+    """Arguments for training."""
+
+    learning_rate: float | None = None
+    batch_size: int | None = None
+    num_epochs: int | None = None
+    warmup_steps: int | None = None
+    weight_decay: float | None = None
+    custom_kwargs: dict[str, Any] = Field(default_factory=dict)

--- a/tests/trainers/pytorch/conftest.py
+++ b/tests/trainers/pytorch/conftest.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+import numpy as np
+import pytest
+from torch.utils.data import DataLoader, Dataset
+
+from fed_rag.base.trainer import BaseGeneratorTrainer, BaseRetrieverTrainer
+from fed_rag.trainers.pytorch.mixin import PyTorchTrainerMixin
+from fed_rag.types.results import TestResult, TrainResult
+
+
+class TestRetrieverTrainer(PyTorchTrainerMixin, BaseRetrieverTrainer):
+    __test__ = (
+        False  # needed for Pytest collision. Avoids PytestCollectionWarning
+    )
+
+    def train(self) -> TrainResult:
+        return TrainResult(loss=0.42)
+
+    def evaluate(self) -> TestResult:
+        return TestResult(loss=0.42)
+
+
+class TestGeneratorTrainer(PyTorchTrainerMixin, BaseGeneratorTrainer):
+    __test__ = (
+        False  # needed for Pytest collision. Avoids PytestCollectionWarning
+    )
+
+    def train(self) -> TrainResult:
+        return TrainResult(loss=0.42)
+
+    def evaluate(self) -> TestResult:
+        return TestResult(loss=0.42)
+
+
+class _TestDataset(Dataset):
+    def __init__(self, size: int) -> None:
+        self.features = np.random.rand(size, 2)
+        self.labels = np.random.choice(2, size=size)
+
+    def __len__(self) -> int:
+        return len(self.labels)
+
+    def __getitem__(self, index: int) -> tuple[np.ndarray, Any]:
+        return self.features[index], self.labels[index]
+
+
+@pytest.fixture()
+def train_dataset() -> Dataset:
+    return _TestDataset(size=10)
+
+
+@pytest.fixture()
+def train_dataloader(train_dataset: Dataset) -> DataLoader:
+    return DataLoader(train_dataset, batch_size=2, shuffle=True)

--- a/tests/trainers/pytorch/conftest.py
+++ b/tests/trainers/pytorch/conftest.py
@@ -51,5 +51,10 @@ def train_dataset() -> Dataset:
 
 
 @pytest.fixture()
+def another_train_dataset() -> Dataset:
+    return _TestDataset(size=10)
+
+
+@pytest.fixture()
 def train_dataloader(train_dataset: Dataset) -> DataLoader:
     return DataLoader(train_dataset, batch_size=2, shuffle=True)

--- a/tests/trainers/pytorch/test_pt_mixin.py
+++ b/tests/trainers/pytorch/test_pt_mixin.py
@@ -1,22 +1,19 @@
-from pytest import MonkeyPatch
+import pytest
 from torch.utils.data import DataLoader, Dataset
 
 from fed_rag.base.trainer import BaseTrainer
+from fed_rag.exceptions import InconsistentDatasetError
 from fed_rag.trainers.pytorch import PyTorchTrainerProtocol, TrainingArgs
 from fed_rag.types.rag_system import RAGSystem
 
-from .conftest import TestGeneratorTrainer
+from .conftest import TestGeneratorTrainer, TestRetrieverTrainer
 
 
-def test_hf_trainer_init(
+def test_pt_trainer_init(
     mock_rag_system: RAGSystem,
     train_dataset: Dataset,
     train_dataloader: DataLoader,
-    monkeypatch: MonkeyPatch,
 ) -> None:
-    # skip validation of rag system
-    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
-
     # arrange
     training_args = TrainingArgs()
     trainer = TestGeneratorTrainer(
@@ -32,3 +29,42 @@ def test_hf_trainer_init(
     assert trainer.training_arguments == training_args
     assert isinstance(trainer, PyTorchTrainerProtocol)
     assert isinstance(trainer, BaseTrainer)
+
+
+def test_pt_retriever_trainer(
+    mock_rag_system: RAGSystem,
+    train_dataset: Dataset,
+    train_dataloader: DataLoader,
+) -> None:
+    # arrange
+    trainer = TestRetrieverTrainer(
+        rag_system=mock_rag_system,
+        train_dataloader=train_dataloader,
+    )
+
+    assert trainer.rag_system == mock_rag_system
+    assert trainer.model == mock_rag_system.retriever.encoder
+    assert trainer.train_dataset == train_dataset
+    assert trainer.train_dataloader == train_dataloader
+    assert trainer.training_arguments is None
+    assert isinstance(trainer, PyTorchTrainerProtocol)
+    assert isinstance(trainer, BaseTrainer)
+
+
+def test_pt_trainer_init_raises_inconsistent_dataset_error(
+    mock_rag_system: RAGSystem,
+    another_train_dataset: Dataset,
+    train_dataloader: DataLoader,
+) -> None:
+    msg = (
+        "Inconsistent datasets detected between supplied `train_dataset` and that "
+        "associated with the `train_dataloader`. These two datasets must be the same."
+    )
+
+    with pytest.raises(InconsistentDatasetError, match=msg):
+        # arrange
+        TestGeneratorTrainer(
+            rag_system=mock_rag_system,
+            train_dataset=another_train_dataset,
+            train_dataloader=train_dataloader,
+        )

--- a/tests/trainers/pytorch/test_pt_mixin.py
+++ b/tests/trainers/pytorch/test_pt_mixin.py
@@ -1,0 +1,34 @@
+from pytest import MonkeyPatch
+from torch.utils.data import DataLoader, Dataset
+
+from fed_rag.base.trainer import BaseTrainer
+from fed_rag.trainers.pytorch import PyTorchTrainerProtocol, TrainingArgs
+from fed_rag.types.rag_system import RAGSystem
+
+from .conftest import TestGeneratorTrainer
+
+
+def test_hf_trainer_init(
+    mock_rag_system: RAGSystem,
+    train_dataset: Dataset,
+    train_dataloader: DataLoader,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # skip validation of rag system
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    # arrange
+    training_args = TrainingArgs()
+    trainer = TestGeneratorTrainer(
+        rag_system=mock_rag_system,
+        train_dataloader=train_dataloader,
+        training_arguments=training_args,
+    )
+
+    assert trainer.rag_system == mock_rag_system
+    assert trainer.model == mock_rag_system.generator.model
+    assert trainer.train_dataset == train_dataset
+    assert trainer.train_dataloader == train_dataloader
+    assert trainer.training_arguments == training_args
+    assert isinstance(trainer, PyTorchTrainerProtocol)
+    assert isinstance(trainer, BaseTrainer)


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
We have a similar `HuggingFaceTrainerMixin` that can be used in composition with `BaseTrainer` to create new `HuggingFaceTrainer` classes (e.g., LSRTrainer). We should have a similar abstraction for `PyTorch` native builds.

The main thing here is that instead of `~datasets.Dataset` we use `torch.utils.data.Dataset` and also add the `torch.utils.data.DataLoader` param which we validate for consistency should the user provide the `train_dataset` as well.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved