### PR TITLE
[Feature] Add `HuggingFaceTrainerForRALT` and associated `DataCollatorForRALT`

### DIFF
--- a/src/fed_rag/data_collators/huggingface/__init__.py
+++ b/src/fed_rag/data_collators/huggingface/__init__.py
@@ -3,6 +3,7 @@ import importlib.util
 from fed_rag.exceptions.common import MissingExtraError
 
 from .lsr import DataCollatorForLSR
+from .ralt import DataCollatorForRALT
 
 # check if huggingface extra is installed
 _has_huggingface = (importlib.util.find_spec("transformers") is not None) and (
@@ -15,4 +16,4 @@ if not _has_huggingface:
     )
     raise MissingExtraError(msg)
 
-__all__ = ["DataCollatorForLSR"]
+__all__ = ["DataCollatorForLSR", "DataCollatorForRALT"]

--- a/src/fed_rag/data_collators/huggingface/lsr.py
+++ b/src/fed_rag/data_collators/huggingface/lsr.py
@@ -1,4 +1,4 @@
-"""HuggingFace PeftModel Generator"""
+"""HuggingFace Data Collator For LM-Supervised Retriever Training"""
 
 from typing import Any
 

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -1,0 +1,173 @@
+"""HuggingFace Data Collator For Retrieval-Augmented Generator Training"""
+
+from typing import Any
+
+from pydantic import Field
+
+from fed_rag.base.data_collator import BaseDataCollator
+from fed_rag.exceptions import DataCollatorError, MissingExtraError
+from fed_rag.types.rag_system import RAGSystem
+from fed_rag.utils.huggingface import _validate_rag_system
+
+try:
+    from transformers.data.data_collator import (
+        DataCollatorForLanguageModeling,
+        DataCollatorMixin,
+    )
+
+    _has_huggingface = True
+except ModuleNotFoundError:
+    _has_huggingface = False
+
+    # Create a dummy class with a different name to avoid the redefinition
+    class _DummyDataCollatorMixin:
+        """Dummy placeholder when transformers is not available."""
+
+        pass
+
+    DataCollatorMixin = _DummyDataCollatorMixin  # type: ignore
+
+
+DEFAULT_EXAMPLE_TEMPLATE = """
+You are a helpful assistant. Given the user's question, provide a succinct
+and accurate response. If context is provided, use it in your answer if it helps
+you to create the most accurate response.
+
+<question>
+{query}
+</question>
+
+<context>
+{context}
+</context>
+
+<response>
+{response}
+</response>
+"""
+
+
+class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
+    """A HuggingFace DataCollator for LM-Supervised Retrieval."""
+
+    example_template: str = Field(default=DEFAULT_EXAMPLE_TEMPLATE)
+    default_return_tensors: str = Field(default="pt")
+
+    def __init__(
+        self,
+        rag_system: RAGSystem,
+        example_template: str | None = None,
+        default_return_tensors: str = "pt",
+        **kwargs: Any,
+    ):
+        if not _has_huggingface:
+            msg = (
+                f"`{self.__class__.__name__}` requires `huggingface` extra to be installed. "
+                "To fix please run `pip install fed-rag[huggingface]`."
+            )
+            raise MissingExtraError(msg)
+
+        _validate_rag_system(rag_system)
+
+        example_template = example_template or DEFAULT_EXAMPLE_TEMPLATE
+
+        super().__init__(
+            rag_system=rag_system,
+            example_template=example_template,
+            default_return_tensors=default_return_tensors,
+            **kwargs,
+        )
+
+    def __call__(
+        self, features: list[dict[str, Any]], return_tensors: str | None = None
+    ) -> dict[str, Any]:
+        """Use the features of the dataset in order to get the `input_ids` and `labels`.
+
+        Steps:
+            1. process the features using the RAG system and example template to create
+               the retrieval-augmented lm fine-tuning text
+            2. pass this processed features to ~transformers.DataCollatorForLanguageModeling
+
+
+        Args:
+            features (list[Any]): Should contain a 'query' and 'response' field.
+            return_tensors (_type_, optional): supports right now only 'pt'
+
+        Returns:
+            dict[str, Any]: a dictionary of ~torch.Tensors with keys 'input_ids'
+                and 'labels'
+
+        Note that each ('query', 'response') pair generates rag_system.config.top_k
+        fine-tuning instance for RALT.
+        """
+        return_tensors = (
+            return_tensors if return_tensors else self.default_return_tensors
+        )
+        if return_tensors != "pt":
+            raise DataCollatorError(
+                f"Framework '{return_tensors}' not recognized!"
+            )
+
+        # STEP 1 — use rag system to build the RALT fine-tuning texts
+        inputs_list = []
+        targets_list = []
+        attention_mask_list = []
+        finetuning_instances = []
+        for example in features:
+            # retrieve
+            source_nodes = self.rag_system.retrieve(query=example["query"])
+            total_sum_scores = sum(s.score for s in source_nodes)
+
+            # parallel in-context retrieval-augmentation creates
+            # top_k separated finetuning instances
+            for source in source_nodes:
+                finetune_instance_text = self.finetune_example_template.format(
+                    query=example["query"],
+                    answer=example["response"],
+                    context=source.node.get_content()["text_content"],
+                )
+                finetuning_instances.append(finetune_instance_text)
+                _weight = source.score / total_sum_scores
+
+                # tokenize to get input_ids and target_ids
+                tokenizer = self.rag_system.generator.tokenizer
+                unwrapped_tokenizer = (
+                    self.rag_system.generator.tokenizer.unwrapped
+                )
+                try:
+                    eos_token = unwrapped_tokenizer.special_tokens_map.get(
+                        "eos_token"
+                    )
+                except KeyError:
+                    raise DataCollatorError(
+                        "Tokenizer doesn't have an `eos_token`."
+                    )
+                eos_token_ix = unwrapped_tokenizer.all_special_tokens.index(
+                    eos_token
+                )
+                eos_token_id = unwrapped_tokenizer.all_special_ids[
+                    eos_token_ix
+                ]
+
+                encode_result = tokenizer.encode(finetune_instance_text)
+                input_ids = encode_result["input_ids"]
+                attention_mask = encode_result["attention_mask"]
+                target_ids = input_ids[1:] + [eos_token_id]
+
+                inputs_list.append(input_ids)
+                targets_list.append(target_ids)
+                attention_mask_list.append(attention_mask)
+
+        processed_features = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "target_ids": target_ids,
+        }
+
+        # STEP 2 — Use ~transformers.DataCollatorForLanguageModeling
+        data_collator_for_lm = DataCollatorForLanguageModeling(
+            tokenizer=unwrapped_tokenizer,
+            mlm=False,  # we could implement masking here on instructions
+        )
+
+        return data_collator_for_lm.torch_call(processed_features)  # type: ignore[no-any-return]

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -1,6 +1,6 @@
 """HuggingFace Data Collator For Retrieval-Augmented Generator Training"""
 
-from typing import Any, cast
+from typing import Any
 
 from pydantic import Field
 
@@ -10,7 +10,7 @@ from fed_rag.types.rag_system import RAGSystem
 from fed_rag.utils.huggingface import _validate_rag_system
 
 try:
-    import transformers.data.data_collator as transformers_data_collators
+    # import transformers.data.data_collator as transformers_data_collators
     from transformers.data.data_collator import (
         DataCollatorForLanguageModeling,
         DataCollatorMixin,
@@ -175,10 +175,10 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
             tokenizer=unwrapped_tokenizer,
             mlm=False,  # we could implement masking here on instructions
         )
-        # bring back proper typing
-        data_collator_for_lm = cast(
-            transformers_data_collators.DataCollatorForLanguageModeling,
-            data_collator_for_lm,
-        )
+        # # bring back proper typing
+        # data_collator_for_lm = cast(
+        #     transformers_data_collators.DataCollatorForLanguageModeling,
+        #     data_collator_for_lm,
+        # )
 
         return data_collator_for_lm.torch_call(processed_features)  # type: ignore[no-any-return]

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -1,6 +1,6 @@
 """HuggingFace Data Collator For Retrieval-Augmented Generator Training"""
 
-from typing import Any
+from typing import Any, cast
 
 from pydantic import Field
 
@@ -10,7 +10,7 @@ from fed_rag.types.rag_system import RAGSystem
 from fed_rag.utils.huggingface import _validate_rag_system
 
 try:
-    # import transformers.data.data_collator as transformers_data_collators
+    import transformers.data.data_collator as transformers_data_collators
     from transformers.data.data_collator import (
         DataCollatorForLanguageModeling,
         DataCollatorMixin,
@@ -175,10 +175,10 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
             tokenizer=unwrapped_tokenizer,
             mlm=False,  # we could implement masking here on instructions
         )
-        # # bring back proper typing
-        # data_collator_for_lm = cast(
-        #     transformers_data_collators.DataCollatorForLanguageModeling,
-        #     data_collator_for_lm,
-        # )
+        # bring back proper typing
+        data_collator_for_lm = cast(
+            transformers_data_collators.DataCollatorForLanguageModeling,
+            data_collator_for_lm,
+        )
 
         return data_collator_for_lm.torch_call(processed_features)  # type: ignore[no-any-return]

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -121,9 +121,9 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
             # parallel in-context retrieval-augmentation creates
             # top_k separated finetuning instances
             for source in source_nodes:
-                finetune_instance_text = self.finetune_example_template.format(
+                finetune_instance_text = self.example_template.format(
                     query=example["query"],
-                    answer=example["response"],
+                    response=example["response"],
                     context=source.node.get_content()["text_content"],
                 )
                 finetuning_instances.append(finetune_instance_text)
@@ -159,9 +159,9 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
                 attention_mask_list.append(attention_mask)
 
         processed_features = {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "target_ids": target_ids,
+            "input_ids": inputs_list,
+            "attention_mask": targets_list,
+            "target_ids": attention_mask_list,
         }
 
         # STEP 2 — Use ~transformers.DataCollatorForLanguageModeling

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -160,8 +160,8 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
 
         processed_features = {
             "input_ids": inputs_list,
-            "attention_mask": targets_list,
-            "target_ids": attention_mask_list,
+            "attention_mask": attention_mask_list,
+            "target_ids": targets_list,
         }
 
         # STEP 2 — Use ~transformers.DataCollatorForLanguageModeling

--- a/src/fed_rag/exceptions/__init__.py
+++ b/src/fed_rag/exceptions/__init__.py
@@ -1,5 +1,6 @@
 from .common import MissingExtraError
 from .core import FedRAGError
+from .data_collator import DataCollatorError
 from .fl_tasks import (
     FLTaskError,
     MissingFLTaskConfig,
@@ -38,6 +39,7 @@ __all__ = [
     "FedRAGError",
     # common
     "MissingExtraError",
+    "DataCollatorError",
     # fl_tasks
     "FLTaskError",
     "MissingFLTaskConfig",

--- a/src/fed_rag/exceptions/data_collator.py
+++ b/src/fed_rag/exceptions/data_collator.py
@@ -1,0 +1,7 @@
+from .core import FedRAGError
+
+
+class DataCollatorError(FedRAGError):
+    """Base errors for all data collator relevant exceptions."""
+
+    pass

--- a/src/fed_rag/trainers/huggingface/ralt.py
+++ b/src/fed_rag/trainers/huggingface/ralt.py
@@ -1,0 +1,79 @@
+"""HuggingFace Retrieval-Augmented Generator Trainer"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from pydantic import PrivateAttr, model_validator
+
+from fed_rag.base.trainer import BaseGeneratorTrainer
+from fed_rag.data_collators.huggingface.ralt import DataCollatorForRALT
+from fed_rag.trainers.huggingface.mixin import HuggingFaceTrainerMixin
+from fed_rag.types.rag_system import RAGSystem
+from fed_rag.types.results import TestResult, TrainResult
+from fed_rag.utils.huggingface import _validate_rag_system
+
+try:
+    from transformers import Trainer
+
+    _has_huggingface = True
+except ModuleNotFoundError:
+    _has_huggingface = False
+
+    class Trainer:  # type: ignore[no-redef]
+        """Dummy placeholder when transformers is not available."""
+
+        pass
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from datasets import Dataset
+    from sentence_transformers import SentenceTransformerTrainer
+    from transformers import Trainer, TrainingArguments
+    from transformers.trainer_utils import TrainOutput
+
+
+class HuggingFaceTrainerForRALT(HuggingFaceTrainerMixin, BaseGeneratorTrainer):
+    """HuggingFace Trainer for Retrieval-Augmented LM Training/Fine-Tuning."""
+
+    _hf_trainer: Optional["Trainer"] = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        rag_system: RAGSystem,
+        train_dataset: "Dataset",
+        training_arguments: Optional["TrainingArguments"] = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            train_dataset=train_dataset,
+            rag_system=rag_system,
+            training_arguments=training_arguments,
+            **kwargs,
+        )
+
+    @model_validator(mode="after")
+    def set_private_attributes(self) -> "HuggingFaceTrainerForRALT":
+        # if made it to here, then this import is available
+        from transformers import Trainer
+
+        # validate rag system
+        _validate_rag_system(self.rag_system)
+
+        self._hf_trainer = Trainer(
+            model=self.model,
+            args=self.training_arguments,
+            data_collator=DataCollatorForRALT(rag_system=self.rag_system),
+        )
+
+        return self
+
+    def train(self) -> TrainResult:
+        output: TrainOutput = self.hf_trainer_obj.train()
+        return TrainResult(loss=output.training_loss)
+
+    def evaluate(self) -> TestResult:
+        # TODO: implement this
+        raise NotImplementedError
+
+    @property
+    def hf_trainer_obj(self) -> "SentenceTransformerTrainer":
+        return self._hf_trainer

--- a/src/fed_rag/trainers/huggingface/ralt.py
+++ b/src/fed_rag/trainers/huggingface/ralt.py
@@ -26,7 +26,6 @@ except ModuleNotFoundError:
 
 if TYPE_CHECKING:  # pragma: no cover
     from datasets import Dataset
-    from sentence_transformers import SentenceTransformerTrainer
     from transformers import Trainer, TrainingArguments
     from transformers.trainer_utils import TrainOutput
 
@@ -75,5 +74,5 @@ class HuggingFaceTrainerForRALT(HuggingFaceTrainerMixin, BaseGeneratorTrainer):
         raise NotImplementedError
 
     @property
-    def hf_trainer_obj(self) -> "SentenceTransformerTrainer":
+    def hf_trainer_obj(self) -> "Trainer":
         return self._hf_trainer

--- a/tests/data_collators/huggingface/conftest.py
+++ b/tests/data_collators/huggingface/conftest.py
@@ -73,6 +73,10 @@ class MockGenerator(BaseGenerator):
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
 
+    @tokenizer.setter
+    def tokenizer(self, v: Any) -> None:
+        self._tokenizer = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/data_collators/huggingface/test_data_collator_for_ralt.py
+++ b/tests/data_collators/huggingface/test_data_collator_for_ralt.py
@@ -176,13 +176,9 @@ def mock_examples() -> Sequence[dict]:
     DataCollatorForLanguageModeling,
     "torch_call",
 )
-@patch(
-    "fed_rag.data_collators.huggingface.ralt.DataCollatorForLanguageModeling"
-)
 @patch.object(RAGSystem, "retrieve")
 def test_lsr_collator_with_mocks(
     mock_retrieve: MagicMock,
-    mock_hf_data_collator_for_lm_class: MagicMock,
     mock_torch_call: MagicMock,
     mock_rag_system: RAGSystem,
     mock_examples: Sequence[dict],
@@ -248,9 +244,6 @@ def test_lsr_collator_with_mocks(
     # Create a mock instance to be returned when the class is instantiated
     # mock_torch_call = MagicMock()
     mock_torch_call.side_effect = _mock_torch_call
-    mock_collator_instance = MagicMock()
-    mock_collator_instance.torch_call = mock_torch_call
-    mock_hf_data_collator_for_lm_class.return_value = mock_collator_instance
 
     # arrange collator
     collator = DataCollatorForRALT(
@@ -263,7 +256,6 @@ def test_lsr_collator_with_mocks(
 
     expected_num_examples = mock_top_k_val * len(mock_examples)
     assert collated_batch["input_ids"].shape[0] == expected_num_examples
-    mock_hf_data_collator_for_lm_class.assert_called_once()
     mock_torch_call.assert_called_once()
     assert_close(
         collated_batch["input_ids"],

--- a/tests/data_collators/huggingface/test_data_collator_for_ralt.py
+++ b/tests/data_collators/huggingface/test_data_collator_for_ralt.py
@@ -1,0 +1,251 @@
+import re
+import sys
+from unittest.mock import MagicMock, _Call, patch
+
+import pytest
+import torch
+from pytest import MonkeyPatch
+from torch.testing import assert_close
+
+from fed_rag.data_collators.huggingface.ralt import (
+    DEFAULT_EXAMPLE_TEMPLATE,
+    DataCollatorForRALT,
+)
+from fed_rag.exceptions import FedRAGError, MissingExtraError
+from fed_rag.generators.huggingface import HFPeftModelGenerator
+from fed_rag.retrievers.huggingface.hf_sentence_transformer import (
+    HFSentenceTransformerRetriever,
+)
+from fed_rag.types.knowledge_node import KnowledgeNode
+from fed_rag.types.rag_system import RAGSystem, SourceNode
+
+
+def test_huggingface_extra_missing(mock_rag_system: RAGSystem) -> None:
+    """Test extra is not installed."""
+
+    modules = {
+        "transformers": None,
+        "transformers.data": None,
+        "transformers.data.data_collator": None,
+    }
+    module_to_import = "fed_rag.data_collators.huggingface.ralt"
+    original_module = sys.modules.pop(module_to_import, None)
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`DataCollatorForRALT` requires `huggingface` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            from fed_rag.data_collators.huggingface.ralt import (
+                DataCollatorForRALT,
+            )
+
+            DataCollatorForRALT(
+                rag_system=mock_rag_system,
+            )
+
+    # restore module so to not affect other tests
+    if original_module:
+        sys.modules[module_to_import] = original_module
+
+
+def test_huggingface_extra_missing_from_parent(
+    mock_rag_system: RAGSystem,
+) -> None:
+    """Test extra is not installed."""
+
+    modules = {
+        "transformers": None,
+        "transformers.data": None,
+        "transformers.data.data_collator": None,
+    }
+    module_to_import = "fed_rag.data_collators.huggingface"
+    original_module = sys.modules.pop(module_to_import, None)
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`fed_rag.data_collators.huggingface` requires `huggingface` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            from fed_rag.data_collators.huggingface import DataCollatorForRALT
+
+            DataCollatorForRALT(
+                rag_system=mock_rag_system,
+                prompt_template="{query} and {context}",
+            )
+
+    # restore module so to not affect other tests
+    if original_module:
+        sys.modules[module_to_import] = original_module
+
+
+def test_invalid_rag_system_due_to_generators(
+    mock_rag_system: RAGSystem,
+) -> None:
+    with pytest.raises(
+        FedRAGError,
+        match="Generator must be HFPretrainedModelGenerator or HFPeftModelGenerator",
+    ):
+        from fed_rag.data_collators.huggingface import DataCollatorForRALT
+
+        DataCollatorForRALT(rag_system=mock_rag_system)
+
+
+def test_invalid_rag_system_due_to_retriever(
+    mock_rag_system: RAGSystem,
+) -> None:
+    generator = HFPeftModelGenerator(
+        model_name="fake_name",
+        base_model_name="fake_base_name",
+        load_model_at_init=False,
+    )
+    mock_rag_system.generator = generator
+
+    with pytest.raises(
+        FedRAGError,
+        match="Retriever must be a HFSentenceTransformerRetriever",
+    ):
+        from fed_rag.data_collators.huggingface import DataCollatorForRALT
+
+        DataCollatorForRALT(rag_system=mock_rag_system, prompt_template="")
+
+
+def test_invalid_return_tensors(
+    mock_rag_system: RAGSystem,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+    return_tensors = "af"
+    with pytest.raises(
+        FedRAGError,
+        match=f"Framework '{return_tensors}' not recognized!",
+    ):
+        collator = DataCollatorForRALT(
+            rag_system=mock_rag_system, prompt_template=""
+        )
+        collator([], return_tensors)
+
+
+def test_init(
+    mock_rag_system: RAGSystem,
+) -> None:
+    generator = HFPeftModelGenerator(
+        model_name="fake_name",
+        base_model_name="fake_base_name",
+        load_model_at_init=False,
+    )
+    retriever = HFSentenceTransformerRetriever(
+        model_name="fake_name", load_model_at_init=False
+    )
+    mock_rag_system.generator = generator
+    mock_rag_system.retriever = retriever
+
+    collator = DataCollatorForRALT(
+        rag_system=mock_rag_system,
+    )
+
+    assert collator.rag_system == mock_rag_system
+    assert collator.example_template == DEFAULT_EXAMPLE_TEMPLATE
+    assert collator.default_return_tensors == "pt"
+
+
+@patch.object(RAGSystem, "retrieve")
+def test_lsr_collator_with_mocks(
+    mock_retrieve: MagicMock,
+    mock_rag_system: RAGSystem,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # Set environment variable for the duration of this test only
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    rag_system = RAGSystem(
+        generator=mock_rag_system.generator,
+        retriever=mock_rag_system.retriever,
+        knowledge_store=mock_rag_system.knowledge_store,
+        rag_config=mock_rag_system.rag_config,
+    )
+
+    # use mocks
+    mock_generator = MagicMock()
+    mock_generator.compute_target_sequence_proba.side_effect = [
+        torch.tensor(0.01),
+        torch.tensor(0.02),
+        torch.tensor(0.03),
+    ]
+    rag_system.generator = mock_generator
+
+    mock_retrieve.return_value = [
+        SourceNode(
+            score=0.1,
+            node=KnowledgeNode(
+                embedding=[0.1], node_type="text", text_content="node 1"
+            ),
+        ),
+        SourceNode(
+            score=0.2,
+            node=KnowledgeNode(
+                embedding=[0.2], node_type="text", text_content="node 2"
+            ),
+        ),
+        SourceNode(
+            score=0.3,
+            node=KnowledgeNode(
+                embedding=[0.3], node_type="text", text_content="node 3"
+            ),
+        ),
+    ]
+
+    collator = DataCollatorForRALT(
+        rag_system=rag_system, example_template="{query} {context} {response}"
+    )
+
+    # act
+    features = [{"query": "mock query", "response": "mock response"}]
+    batch = collator(features)
+
+    assert_close(
+        batch["retrieval_scores"], torch.tensor([0.1, 0.2, 0.3]).unsqueeze(0)
+    )
+    assert_close(
+        batch["lm_scores"], torch.tensor([0.01, 0.02, 0.03]).unsqueeze(0)
+    )
+    mock_retrieve.assert_called_once_with("mock query")
+    mock_generator.compute_target_sequence_proba.assert_has_calls(
+        [
+            _Call(
+                (
+                    (),
+                    {
+                        "prompt": "mock query node 1",
+                        "target": "\n<response>\nmock response\n</response>\n",
+                    },
+                )
+            ),
+            _Call(
+                (
+                    (),
+                    {
+                        "prompt": "mock query node 2",
+                        "target": "\n<response>\nmock response\n</response>\n",
+                    },
+                )
+            ),
+            _Call(
+                (
+                    (),
+                    {
+                        "prompt": "mock query node 3",
+                        "target": "\n<response>\nmock response\n</response>\n",
+                    },
+                )
+            ),
+        ]
+    )

--- a/tests/data_collators/huggingface/test_data_collator_for_ralt.py
+++ b/tests/data_collators/huggingface/test_data_collator_for_ralt.py
@@ -164,7 +164,7 @@ def mock_examples() -> Sequence[dict]:
     return [
         {
             "query": f"fake query {ix}",
-            "answer": f"fake answer {ix}",
+            "response": f"fake response {ix}",
             "context": f"fake context {ix}",
         }
         for ix in range(2)

--- a/tests/data_collators/huggingface/test_data_collator_for_ralt.py
+++ b/tests/data_collators/huggingface/test_data_collator_for_ralt.py
@@ -11,6 +11,7 @@ from torch.testing import assert_close
 from fed_rag.base.tokenizer import EncodeResult
 from fed_rag.data_collators.huggingface.ralt import (
     DEFAULT_EXAMPLE_TEMPLATE,
+    DataCollatorForLanguageModeling,
     DataCollatorForRALT,
 )
 from fed_rag.exceptions import FedRAGError, MissingExtraError
@@ -171,6 +172,10 @@ def mock_examples() -> Sequence[dict]:
     ]
 
 
+@patch.object(
+    DataCollatorForLanguageModeling,
+    "torch_call",
+)
 @patch(
     "fed_rag.data_collators.huggingface.ralt.DataCollatorForLanguageModeling"
 )
@@ -178,6 +183,7 @@ def mock_examples() -> Sequence[dict]:
 def test_lsr_collator_with_mocks(
     mock_retrieve: MagicMock,
     mock_hf_data_collator_for_lm_class: MagicMock,
+    mock_torch_call: MagicMock,
     mock_rag_system: RAGSystem,
     mock_examples: Sequence[dict],
     monkeypatch: MonkeyPatch,
@@ -240,7 +246,7 @@ def test_lsr_collator_with_mocks(
         return retval
 
     # Create a mock instance to be returned when the class is instantiated
-    mock_torch_call = MagicMock()
+    # mock_torch_call = MagicMock()
     mock_torch_call.side_effect = _mock_torch_call
     mock_collator_instance = MagicMock()
     mock_collator_instance.torch_call = mock_torch_call

--- a/tests/trainers/huggingface/test_hf_ralt.py
+++ b/tests/trainers/huggingface/test_hf_ralt.py
@@ -1,0 +1,119 @@
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+from pytest import MonkeyPatch
+from transformers import Trainer
+from transformers.trainer_utils import TrainOutput
+
+from fed_rag.exceptions import FedRAGError, MissingExtraError
+from fed_rag.trainers.huggingface.ralt import HuggingFaceTrainerForRALT
+from fed_rag.types.rag_system import RAGSystem
+
+
+def test_init(
+    hf_rag_system: RAGSystem, train_dataset: Dataset, monkeypatch: MonkeyPatch
+) -> None:
+    # skip validation of rag system
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    trainer = HuggingFaceTrainerForRALT(
+        rag_system=hf_rag_system,
+        train_dataset=train_dataset,
+    )
+
+    assert trainer.train_dataset == train_dataset
+    assert trainer.model == hf_rag_system.generator.model
+    assert trainer.rag_system == hf_rag_system
+    assert isinstance(trainer.hf_trainer_obj, Trainer)
+
+
+def test_init_raises_invalid_rag_system_error(
+    mock_rag_system: RAGSystem,
+    train_dataset: Dataset,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    with pytest.raises(FedRAGError):
+        HuggingFaceTrainerForRALT(
+            rag_system=mock_rag_system,
+            train_dataset=train_dataset,
+        )
+
+
+def test_huggingface_extra_missing(
+    train_dataset: Dataset, hf_rag_system: RAGSystem, monkeypatch: MonkeyPatch
+) -> None:
+    modules = {
+        "transformers": None,
+    }
+    modules_to_import = [
+        "fed_rag.trainers.huggingface.mixin",
+        "fed_rag.trainers.huggingface.ralt",
+    ]
+    original_modules = [sys.modules.pop(m, None) for m in modules_to_import]
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`HuggingFaceTrainerForRALT` requires `huggingface` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            from fed_rag.trainers.huggingface.ralt import (
+                HuggingFaceTrainerForRALT,
+            )
+
+            HuggingFaceTrainerForRALT(
+                rag_system=hf_rag_system,
+                train_dataset=train_dataset,
+            )
+
+    # restore module so to not affect other tests
+    for ix, original_module in enumerate(original_modules):
+        if original_module:
+            sys.modules[modules_to_import[ix]] = original_module
+
+
+@patch.object(HuggingFaceTrainerForRALT, "hf_trainer_obj")
+def test_train(
+    mock_hf_trainer: MagicMock,
+    hf_rag_system: RAGSystem,
+    train_dataset: Dataset,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # skip validation of rag system
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    trainer = HuggingFaceTrainerForRALT(
+        rag_system=hf_rag_system,
+        train_dataset=train_dataset,
+    )
+    mock_hf_trainer.train.return_value = TrainOutput(
+        global_step=42, training_loss=0.42, metrics={}
+    )
+
+    out = trainer.train()
+
+    mock_hf_trainer.train.assert_called_once()
+    assert out.loss == 0.42
+
+
+def test_evaluate(
+    hf_rag_system: RAGSystem,
+    train_dataset: Dataset,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # skip validation of rag system
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    trainer = HuggingFaceTrainerForRALT(
+        train_dataset=train_dataset,
+        rag_system=hf_rag_system,
+    )
+
+    with pytest.raises(NotImplementedError):
+        trainer.evaluate()


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
We recently re-jigged our trainer core abstractions when implementing LSR for retriever fine-tuning. Generally speaking,

- `~fed_rag.BaseDataCollator` to process examples which are of type `list[{"query": ..., "response": ...}]` to become batches of `torch.Tensors`
- `~fed_rag.BaseTrainer` that handles training of the component (retriever or generator) on these collated examples

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [ ] Unit tests added or updated
- [ ] All tests pass locally (`make test`)
- [] Code coverage maintained or improved
