### PR TITLE
[Fix] Various bugs to make LSR trainer work

### DIFF
--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -39,6 +39,11 @@ You are a helpful assistant. Given the user's question, provide a succinct
 and accurate response. If context is provided, use it in your answer if it helps
 you to create the most accurate response.
 
+<warning>
+Only use the the provided context if its relevant to answer the question. Otherwise,
+ignore it and use your parametric knowledge to answer the question.
+</warning>
+
 <question>
 {query}
 </question>

--- a/src/fed_rag/loss/pytorch/lsr.py
+++ b/src/fed_rag/loss/pytorch/lsr.py
@@ -49,9 +49,9 @@ class LSRLoss(nn.Module):
     def forward(
         self, retrieval_scores: torch.Tensor, lm_scores: torch.Tensor
     ) -> torch.Tensor:
-        retrieval_probs = F.softmax(retrieval_scores, dim=1)
+        retrieval_log_probs = F.log_softmax(retrieval_scores, dim=1)
         lm_probs = F.softmax(lm_scores, dim=1)
-        kl_div = F.kl_div(retrieval_probs, lm_probs, reduction="none").sum(
+        kl_div = F.kl_div(retrieval_log_probs, lm_probs, reduction="none").sum(
             dim=-1
         )
 

--- a/src/fed_rag/trainer_managers/huggingface.py
+++ b/src/fed_rag/trainer_managers/huggingface.py
@@ -53,36 +53,52 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         )
 
     def _prepare_generator_for_training(self, **kwargs: Any) -> None:
-        pass  # no-op
+        self.generator_trainer.model.train()
+
+        # freeze generator
+        if self.retriever_trainer:
+            self.retriever_trainer.model.eval()
+
+            # Ensure all retriever parameters are frozen
+            for param in self.retriever_trainer.model.parameters():
+                param.requires_grad = False
 
     def _prepare_retriever_for_training(
         self, freeze_context_encoder: bool = True, **kwargs: Any
     ) -> None:
-        pass  # no-op
+        self.retriever_trainer.model.train()
 
-    def _train_retriever(self, **kwargs: Any) -> None:
+        # freeze generator
+        if self.generator_trainer:
+            self.generator_trainer.model.eval()
+
+            # Ensure all generator parameters are frozen
+            for param in self.generator_trainer.model.parameters():
+                param.requires_grad = False
+
+    def _train_retriever(self, **kwargs: Any) -> TrainResult:
         self._prepare_retriever_for_training()
         if self.retriever_trainer:
-            self.retriever_trainer.train()
+            return self.retriever_trainer.train()
         else:
             raise UnspecifiedRetrieverTrainer(
                 "Attempted to perform retriever trainer with an unspecified trainer function."
             )
 
-    def _train_generator(self, **kwargs: Any) -> None:
+    def _train_generator(self, **kwargs: Any) -> TrainResult:
         self._prepare_generator_for_training()
         if self.generator_trainer:
-            self.generator_trainer.train()
+            return self.generator_trainer.train()
         else:
             raise UnspecifiedGeneratorTrainer(
                 "Attempted to perform generator trainer with an unspecified trainer function."
             )
 
-    def train(self, **kwargs: Any) -> None:
+    def train(self, **kwargs: Any) -> TrainResult:
         if self.mode == "retriever":
-            self._train_retriever()
+            return self._train_retriever()
         elif self.mode == "generator":
-            self._train_generator()
+            return self._train_generator()
         else:
             assert_never(self.mode)  # pragma: no cover
 

--- a/src/fed_rag/trainer_managers/huggingface.py
+++ b/src/fed_rag/trainer_managers/huggingface.py
@@ -59,10 +59,6 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         if self.retriever_trainer:
             self.retriever_trainer.model.eval()
 
-            # Ensure all retriever parameters are frozen
-            for param in self.retriever_trainer.model.parameters():
-                param.requires_grad = False
-
     def _prepare_retriever_for_training(
         self, freeze_context_encoder: bool = True, **kwargs: Any
     ) -> None:
@@ -71,10 +67,6 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         # freeze generator
         if self.generator_trainer:
             self.generator_trainer.model.eval()
-
-            # Ensure all generator parameters are frozen
-            for param in self.generator_trainer.model.parameters():
-                param.requires_grad = False
 
     def _train_retriever(self, **kwargs: Any) -> TrainResult:
         self._prepare_retriever_for_training()

--- a/src/fed_rag/trainers/huggingface/lsr.py
+++ b/src/fed_rag/trainers/huggingface/lsr.py
@@ -164,6 +164,7 @@ class HuggingFaceTrainerForLSR(HuggingFaceTrainerMixin, BaseRetrieverTrainer):
             model=self.model,
             args=self.training_arguments,
             data_collator=DataCollatorForLSR(rag_system=self.rag_system),
+            train_dataset=self.train_dataset,
         )
 
         return self

--- a/src/fed_rag/trainers/huggingface/ralt.py
+++ b/src/fed_rag/trainers/huggingface/ralt.py
@@ -61,6 +61,7 @@ class HuggingFaceTrainerForRALT(HuggingFaceTrainerMixin, BaseGeneratorTrainer):
             model=self.model,
             args=self.training_arguments,
             data_collator=DataCollatorForRALT(rag_system=self.rag_system),
+            train_dataset=self.train_dataset,
         )
 
         return self

--- a/tests/data_collators/huggingface/test_hf_data_collators.py
+++ b/tests/data_collators/huggingface/test_hf_data_collators.py
@@ -22,9 +22,8 @@ def test_huggingface_extra_missing(mock_rag_system: RAGSystem) -> None:
     """Test extra is not installed."""
 
     modules = {
-        "transformers": None,
-        "transformers.data": None,
-        "transformers.data.data_collator": None,
+        "sentence_transformers": None,
+        "sentence_transformers.data_collator": None,
     }
     module_to_import = "fed_rag.data_collators.huggingface.lsr"
     original_module = sys.modules.pop(module_to_import, None)

--- a/tests/loss/pytorch/test_lsr.py
+++ b/tests/loss/pytorch/test_lsr.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, _Call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -40,11 +40,10 @@ def test_lsr_forward_with_mocks(
     out = loss(retrieval_scores, lm_logits)
 
     # assert
-    calls = [
-        _Call(((retrieval_scores,), {"dim": 1})),
-        _Call(((lm_logits,), {"dim": 1})),
-    ]
-    mock_torch_functional.softmax.assert_has_calls(calls)
+    mock_torch_functional.log_softmax.assert_called_once_with(
+        retrieval_scores, dim=1
+    )
+    mock_torch_functional.softmax.assert_called_once_with(lm_logits, dim=1)
     mock_torch_functional.kl_div.assert_called_once()
     assert out == torch.Tensor([expected])
 
@@ -68,4 +67,4 @@ def test_lsr_expected_output_with_sample_data(
     out = loss(retriever_scores, lm_scores)
 
     assert retrieved_chunks.shape == (2, 3, 10)
-    assert_close(out, torch.tensor(-1.3212032318115234))
+    assert_close(out, torch.tensor(5.661825180053711))

--- a/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
+++ b/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
@@ -274,11 +274,18 @@ def test_prepare_generator_for_training(
     manager.generator_trainer.model = mock_generator_model
     manager.retriever_trainer.model = mock_retriever_model
 
+    # Check parameters before
+    for param in generator_trainer.model.parameters():
+        assert param.requires_grad is True  # They should start unfrozen
+
     # act
     manager._prepare_generator_for_training()
 
+    # assert
     mock_generator_model.train.assert_called_once()
     mock_retriever_model.eval.assert_called_once()
+    for param in generator_trainer.model.parameters():
+        assert param.requires_grad is False  # They should now be frozen
 
 
 def test_prepare_retriever_for_training(
@@ -299,8 +306,15 @@ def test_prepare_retriever_for_training(
     manager.generator_trainer.model = mock_generator_model
     manager.retriever_trainer.model = mock_retriever_model
 
+    # Check parameters before
+    for param in retriever_trainer.model.parameters():
+        assert param.requires_grad is True  # They should start unfrozen
+
     # act
     manager._prepare_retriever_for_training()
 
+    # assert
     mock_generator_model.eval.assert_called_once()
     mock_retriever_model.train.assert_called_once()
+    for param in retriever_trainer.model.parameters():
+        assert param.requires_grad is False  # They should now be frozen

--- a/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
+++ b/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from contextlib import nullcontext as does_not_raise
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -279,7 +280,8 @@ def test_prepare_generator_for_training(
         assert param.requires_grad is True  # They should start unfrozen
 
     # act
-    manager._prepare_generator_for_training()
+    with does_not_raise():
+        manager._prepare_generator_for_training()
 
     # assert
     mock_generator_model.train.assert_called_once()
@@ -311,7 +313,8 @@ def test_prepare_retriever_for_training(
         assert param.requires_grad is True  # They should start unfrozen
 
     # act
-    manager._prepare_retriever_for_training()
+    with does_not_raise():
+        manager._prepare_retriever_for_training()
 
     # assert
     mock_generator_model.eval.assert_called_once()

--- a/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
+++ b/tests/trainer_managers/huggingface/test_hf_trainer_manager.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from contextlib import nullcontext as does_not_raise
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -258,28 +257,50 @@ def test_get_federated_task_raises_unspecified_trainers(
 
 
 def test_prepare_generator_for_training(
+    generator_trainer: BaseGeneratorTrainer,
+    retriever_trainer: BaseRetrieverTrainer,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    # skip validation of rag system
     monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
-
-    trainer = HuggingFaceRAGTrainerManager(
+    manager = HuggingFaceRAGTrainerManager(
         mode="generator",
+        generator_trainer=generator_trainer,
+        retriever_trainer=retriever_trainer,
     )
 
-    with does_not_raise():
-        trainer._prepare_generator_for_training()
+    # add mocks
+    mock_generator_model = MagicMock()
+    mock_retriever_model = MagicMock()
+    manager.generator_trainer.model = mock_generator_model
+    manager.retriever_trainer.model = mock_retriever_model
+
+    # act
+    manager._prepare_generator_for_training()
+
+    mock_generator_model.train.assert_called_once()
+    mock_retriever_model.eval.assert_called_once()
 
 
 def test_prepare_retriever_for_training(
+    generator_trainer: BaseGeneratorTrainer,
+    retriever_trainer: BaseRetrieverTrainer,
     monkeypatch: MonkeyPatch,
 ) -> None:
-    # skip validation of rag system
     monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
-
-    trainer = HuggingFaceRAGTrainerManager(
+    manager = HuggingFaceRAGTrainerManager(
         mode="retriever",
+        generator_trainer=generator_trainer,
+        retriever_trainer=retriever_trainer,
     )
 
-    with does_not_raise():
-        trainer._prepare_retriever_for_training()
+    # add mocks
+    mock_generator_model = MagicMock()
+    mock_retriever_model = MagicMock()
+    manager.generator_trainer.model = mock_generator_model
+    manager.retriever_trainer.model = mock_retriever_model
+
+    # act
+    manager._prepare_retriever_for_training()
+
+    mock_generator_model.eval.assert_called_once()
+    mock_retriever_model.train.assert_called_once()

--- a/tests/trainers/huggingface/conftest.py
+++ b/tests/trainers/huggingface/conftest.py
@@ -53,6 +53,14 @@ def train_dataset() -> Dataset:
 @pytest.fixture()
 def hf_rag_system(mock_rag_system: RAGSystem) -> RAGSystem:
     encoder = SentenceTransformer(modules=[torch.nn.Linear(5, 5)])
+    # Mock the tokenize method on the first module
     encoder.tokenizer = None
+    encoder._first_module().tokenize = lambda texts: {
+        "input_ids": torch.ones((len(texts), 10))
+    }
+    encoder.encode = lambda texts, **kwargs: torch.ones(
+        (len(texts) if isinstance(texts, list) else 1, 5)
+    )
+
     mock_rag_system.retriever.encoder = encoder
     return mock_rag_system


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
In attempt to make `HuggingFaceTrainerForLSR` work for RA-DIT example, I found various bugs that prevented this from all working. This PR makes the following fixes:

1. `fed_rag.loss.pytorch.LSRLoss` — the input to KL divergence should be in the log space
2. `fed_rag.data_collators.huggingface.lsr` - This should subclass `SentenceTransformerDataCollator` instead as we use `SentenceTransformerTrainer`.
3. `fed_rag.data_collators.huggingface.lsr.DataCollatorForLSR` — should require grads for retriever's for retriever scores, but not for lm scores
4. `fed_rag.trainer_managers.huggingface.HuggingFaceTrainerManager` — added implementations for preparing retriever/generator models for training.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [ ] Code coverage maintained or improved

