### PR TITLE
Move validation of the presence of trainers to `BaseTrainerManager`

### DIFF
--- a/examples/ra-dit/uv.lock
+++ b/examples/ra-dit/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "fed-rag"
-version = "0.0.12"
+version = "0.0.11"
 source = { editable = "../../" }
 dependencies = [
     { name = "datasets" },

--- a/examples/ra-dit/uv.lock
+++ b/examples/ra-dit/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "fed-rag"
-version = "0.0.11"
+version = "0.0.12"
 source = { editable = "../../" }
 dependencies = [
     { name = "datasets" },

--- a/src/fed_rag/base/trainer_manager.py
+++ b/src/fed_rag/base/trainer_manager.py
@@ -123,6 +123,6 @@ class BaseRAGTrainerManager(BaseModel, ABC):
                 trainer = cast(BaseRetrieverTrainer, self.retriever_trainer)
             case RAGTrainMode.GENERATOR:
                 trainer = cast(BaseGeneratorTrainer, self.generator_trainer)
-            case _:
+            case _:  # pragma: no cover
                 assert_never(self.mode)  # pragma: no cover
         return trainer.model

--- a/src/fed_rag/base/trainer_manager.py
+++ b/src/fed_rag/base/trainer_manager.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from typing_extensions import assert_never
 
 from fed_rag.base.trainer import BaseGeneratorTrainer, BaseRetrieverTrainer
 from fed_rag.exceptions import (
@@ -123,6 +124,5 @@ class BaseRAGTrainerManager(BaseModel, ABC):
             case RAGTrainMode.GENERATOR:
                 trainer = cast(BaseGeneratorTrainer, self.generator_trainer)
             case _:
-                msg = f"Can't get model with an unsupported train mode: {self.mode}"
-                raise UnsupportedTrainerMode(msg)
+                assert_never(self.mode)  # pragma: no cover
         return trainer.model

--- a/src/fed_rag/base/trainer_manager.py
+++ b/src/fed_rag/base/trainer_manager.py
@@ -2,12 +2,17 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from fed_rag.base.trainer import BaseGeneratorTrainer, BaseRetrieverTrainer
-from fed_rag.exceptions import InconsistentRAGSystems, UnsupportedTrainerMode
+from fed_rag.exceptions import (
+    InconsistentRAGSystems,
+    UnspecifiedGeneratorTrainer,
+    UnspecifiedRetrieverTrainer,
+    UnsupportedTrainerMode,
+)
 
 from .fl_task import BaseFLTask
 
@@ -42,6 +47,28 @@ class BaseRAGTrainerManager(BaseModel, ABC):
                 f"Unsupported RAG train mode: {v}. "
                 f"Mode must be one of: {', '.join([m.value for m in RAGTrainMode])}"
             )
+
+    # Validate trainer presence
+    @model_validator(mode="after")
+    def validate_trainers(self) -> "BaseRAGTrainerManager":
+        """Validate trainer requirements."""
+        # Validate trainer presence based on mode
+        if (
+            self.mode == RAGTrainMode.RETRIEVER
+            and self.retriever_trainer is None
+        ):
+            raise UnspecifiedRetrieverTrainer(
+                "Retriever trainer must be set when in retriever mode"
+            )
+        if (
+            self.mode == RAGTrainMode.GENERATOR
+            and self.generator_trainer is None
+        ):
+            raise UnspecifiedGeneratorTrainer(
+                "Generator trainer must be set when in generator mode"
+            )
+
+        return self
 
     @model_validator(mode="after")
     def validate_trainers_consistency(self) -> "BaseRAGTrainerManager":
@@ -86,3 +113,16 @@ class BaseRAGTrainerManager(BaseModel, ABC):
     @abstractmethod
     def get_federated_task(self) -> BaseFLTask:
         """Get the federated task."""
+
+    @property
+    def model(self) -> Any:
+        """Return the model to be trained."""
+        match self.mode:
+            case RAGTrainMode.RETRIEVER:
+                trainer = cast(BaseRetrieverTrainer, self.retriever_trainer)
+            case RAGTrainMode.GENERATOR:
+                trainer = cast(BaseGeneratorTrainer, self.generator_trainer)
+            case _:
+                msg = f"Can't get model with an unsupported train mode: {self.mode}"
+                raise UnsupportedTrainerMode(msg)
+        return trainer.model

--- a/src/fed_rag/data_collators/huggingface/ralt.py
+++ b/src/fed_rag/data_collators/huggingface/ralt.py
@@ -103,11 +103,20 @@ class DataCollatorForRALT(DataCollatorMixin, BaseDataCollator):
         ]  # Labels are the same as input_ids for causal LM
 
         # Get pad token ID
-        if tokenizer.pad_token is None or tokenizer.pad_token_id < 0:
-            raise DataCollatorError(
-                "Asking to pad but the tokenizer does not have a padding token."
-            )
-        pad_token_id = tokenizer.pad_token_id
+        if tokenizer.pad_token is not None:
+            if tokenizer.pad_token_id < 0:
+                raise DataCollatorError(
+                    "Asking to pad but the tokenizer has a value for pad_token_id < 0."
+                )
+            pad_token_id = tokenizer.pad_token_id
+        else:
+            if tokenizer.eos_token_id is not None:
+                pad_token_id = tokenizer.eos_token_id
+            else:
+                raise DataCollatorError(
+                    "Asking to pad but the tokenizer does not have a padding token "
+                    "nor an eos token that can potentially be used in its place."
+                )
 
         # Create padded tensors
         padded_input_ids = []

--- a/src/fed_rag/trainer_managers/huggingface.py
+++ b/src/fed_rag/trainer_managers/huggingface.py
@@ -69,21 +69,21 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
             self.generator_trainer.model.eval()
 
     def _train_retriever(self, **kwargs: Any) -> TrainResult:
-        self._prepare_retriever_for_training()
         if self.retriever_trainer:
+            self._prepare_retriever_for_training()
             return self.retriever_trainer.train()
         else:
             raise UnspecifiedRetrieverTrainer(
-                "Attempted to perform retriever trainer with an unspecified trainer function."
+                "Attempted to perform retriever trainer with an unspecified trainer."
             )
 
     def _train_generator(self, **kwargs: Any) -> TrainResult:
-        self._prepare_generator_for_training()
         if self.generator_trainer:
+            self._prepare_generator_for_training()
             return self.generator_trainer.train()
         else:
             raise UnspecifiedGeneratorTrainer(
-                "Attempted to perform generator trainer with an unspecified trainer function."
+                "Attempted to perform generator trainer with an unspecified trainer."
             )
 
     def train(self, **kwargs: Any) -> TrainResult:
@@ -98,7 +98,7 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         if self.mode == "retriever":
             if self.retriever_trainer is None:
                 raise UnspecifiedRetrieverTrainer(
-                    "Cannot federate an unspecified retriever trainer function."
+                    "Cannot federate an unspecified retriever trainer."
                 )
             retriever_train_fn = self.retriever_trainer.train
             retriever_module = self.retriever_trainer.model
@@ -121,7 +121,7 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         elif self.mode == "generator":
             if self.generator_trainer is None:
                 raise UnspecifiedGeneratorTrainer(
-                    "Cannot federate an unspecified generator trainer function."
+                    "Cannot federate an unspecified generator trainer."
                 )
             generator_train_fn = self.generator_trainer.train
             generator_module = self.generator_trainer.model

--- a/src/fed_rag/trainer_managers/huggingface.py
+++ b/src/fed_rag/trainer_managers/huggingface.py
@@ -106,9 +106,9 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
 
             # Create a standalone function for federation
             def train_wrapper(
-                _mdl: "HFModelType",
-                _train_dataset: "Dataset",
-                _val_dataset: "Dataset",
+                model: "HFModelType",
+                train_dataset: "Dataset",
+                val_dataset: "Dataset",
             ) -> TrainResult:
                 _ = retriever_train_fn()
                 return TrainResult(loss=0)
@@ -128,9 +128,9 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
 
             # Create a standalone function for federation
             def train_wrapper(
-                _mdl: "HFModelType",  # TODO: handle union types in inspector
-                _train_dataset: "Dataset",
-                _val_dataset: "Dataset",
+                model: "HFModelType",  # TODO: handle union types in inspector
+                train_dataset: "Dataset",
+                val_dataset: "Dataset",
             ) -> TrainResult:
                 _ = generator_train_fn()
                 # TODO get loss from out
@@ -151,7 +151,9 @@ class HuggingFaceRAGTrainerManager(BaseRAGTrainerManager):
         # TODO: add logic for getting evaluator/tester and then federate it as well
         # federated_tester = self.get_federated_tester(tester_decorator)
         # For now, using a simple placeholder test function
-        def test_fn(_mdl: "HFModelType", _dataset: "Dataset") -> TestResult:
+        def test_fn(
+            model: "HFModelType", eval_dataset: "Dataset"
+        ) -> TestResult:
             # Implement simple testing or return a placeholder
             return TestResult(loss=0.42, metrics={})  # pragma: no cover
 

--- a/src/fed_rag/trainer_managers/pytorch.py
+++ b/src/fed_rag/trainer_managers/pytorch.py
@@ -48,21 +48,21 @@ class PyTorchRAGTrainerManager(BaseRAGTrainerManager):
             self.generator_trainer.model.eval()
 
     def _train_retriever(self, **kwargs: Any) -> None:
-        self._prepare_retriever_for_training()
         if self.retriever_trainer:
+            self._prepare_retriever_for_training()
             self.retriever_trainer.train()
         else:
             raise UnspecifiedRetrieverTrainer(
-                "Attempted to perform retriever trainer with an unspecified trainer function."
+                "Attempted to perform retriever trainer with an unspecified trainer."
             )
 
     def _train_generator(self, **kwargs: Any) -> None:
-        self._prepare_generator_for_training()
         if self.generator_trainer:
+            self._prepare_generator_for_training()
             self.generator_trainer.train()
         else:
             raise UnspecifiedGeneratorTrainer(
-                "Attempted to perform generator trainer with an unspecified trainer function."
+                "Attempted to perform generator trainer with an unspecified trainer."
             )
 
     def train(self, **kwargs: Any) -> None:
@@ -77,7 +77,7 @@ class PyTorchRAGTrainerManager(BaseRAGTrainerManager):
         if self.mode == "retriever":
             if self.retriever_trainer is None:
                 raise UnspecifiedRetrieverTrainer(
-                    "Cannot federate an unspecified retriever trainer function."
+                    "Cannot federate an unspecified retriever trainer."
                 )
             retriever_train_fn = self.retriever_trainer.train
             retriever_module = self.retriever_trainer.model
@@ -96,7 +96,7 @@ class PyTorchRAGTrainerManager(BaseRAGTrainerManager):
         elif self.mode == "generator":
             if self.generator_trainer is None:
                 raise UnspecifiedGeneratorTrainer(
-                    "Cannot federate an unspecified generator trainer function."
+                    "Cannot federate an unspecified generator trainer."
                 )
             generator_train_fn = self.generator_trainer.train
             generator_module = self.generator_trainer.model

--- a/tests/data_collators/huggingface/test_data_collator_for_ralt.py
+++ b/tests/data_collators/huggingface/test_data_collator_for_ralt.py
@@ -251,7 +251,36 @@ def test_lsr_collator_with_mocks(
     )
 
 
-def test_lsr_collator_raises_data_collator_error_when_missing_pad_token_id(
+def test_lsr_collator_raises_data_collator_error_when_pad_token_id_less_than_0(
+    mock_rag_system: RAGSystem,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FEDRAG_SKIP_VALIDATION", "1")
+
+    # arrange collator
+    collator = DataCollatorForRALT(
+        rag_system=mock_rag_system,
+    )
+
+    # arrange mock tokenizer
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.pad_token = "<PAD>"
+    mock_tokenizer.pad_token_id = -1
+
+    # act
+    with pytest.raises(
+        DataCollatorError,
+        match="Asking to pad but the tokenizer has a value for pad_token_id < 0.",
+    ):
+        collator._apply_padding(
+            max_length=10,
+            inputs_list=[[1, 1, 1]],
+            attention_mask_list=[[2, 2, 2]],
+            tokenizer=mock_tokenizer,
+        )
+
+
+def test_lsr_collator_raises_data_collator_error_when_pad_token_id_an(
     mock_rag_system: RAGSystem,
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -265,12 +294,17 @@ def test_lsr_collator_raises_data_collator_error_when_missing_pad_token_id(
     # arrange mock tokenizer
     mock_tokenizer = MagicMock()
     mock_tokenizer.pad_token = None
-    mock_tokenizer.pad_token_id = -1
+    mock_tokenizer.pad_token_id = 1
+    mock_tokenizer.eos_token_id = None
 
     # act
+    msg = (
+        "Asking to pad but the tokenizer does not have a padding token "
+        "nor an eos token that can potentially be used in its place."
+    )
     with pytest.raises(
         DataCollatorError,
-        match="Asking to pad but the tokenizer does not have a padding token.",
+        match=msg,
     ):
         collator._apply_padding(
             max_length=10,

--- a/tests/trainer_managers/test_base.py
+++ b/tests/trainer_managers/test_base.py
@@ -21,6 +21,11 @@ def test_init(
     assert trainer.retriever_trainer == retriever_trainer
     assert trainer.generator_trainer == generator_trainer
     assert trainer.mode == "generator"
+    assert trainer.model == generator_trainer.model
+
+    # update mode
+    trainer.mode = "retriever"
+    assert trainer.model == retriever_trainer.model
 
 
 def test_invalid_mode_raises_error(


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Code quality / linting
- [ ] Other (please describe):

## Description
In this PR, the biggest improvement is adding another (more better) layer of validation for the presence of trainers in trainer manager objects depending on the specified mode.

Before this PR, this check was happening in the subclasses of `BaseRAGTrainManager` but it should happen in the base class.

Additionally, the following items are also included in this PR:
- Added a convenient `.model` attribute on the `RAGTrainerManager` class that gets the associated retriever or generator model (dependent on the mode).
- Re-jigged the test/trainer signatures when creating `FLTask` via `RAGTrainManager.get_federated_task()`
- Slight logic update for`DataCollatorForRALT` in getting a `pad_token_id`—should be more robust now.
- Added appropriate unit tests and modified ones that needed updating

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved

