### PR TITLE
[Fix] Fix `count` logic within `QdrantKnowledgeStore` 

### DIFF
--- a/src/fed_rag/knowledge_stores/qdrant/sync.py
+++ b/src/fed_rag/knowledge_stores/qdrant/sync.py
@@ -254,25 +254,19 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
 
     @property
     def count(self) -> int:
-        from qdrant_client.http.models import CollectionInfo
+        from qdrant_client.http.models import CountResult
 
         self._ensure_collection_exists()
 
         try:
-            collection_info: CollectionInfo = self.client.get_collection(
+            res: CountResult = self.client.count(
                 collection_name=self.collection_name
             )
+            return int(res.count)
         except Exception as e:
             raise KnowledgeStoreError(
                 f"Failed to get vector count for collection '{self.collection_name}': {str(e)}"
             ) from e
-
-        if collection_info.vectors_count is None:
-            raise KnowledgeStoreError(
-                "Collection exists, but `vectors_count` is None."
-            )
-        else:
-            return int(collection_info.vectors_count)
 
     def persist(self) -> None:
         """Persist a knowledge store to disk."""

--- a/tests/knowledge_stores/test_qdrant.py
+++ b/tests/knowledge_stores/test_qdrant.py
@@ -531,16 +531,16 @@ def test_count(
     mock_qdrant_client_class: MagicMock,
     mock_ensure_collection_exists: MagicMock,
 ) -> None:
+    from qdrant_client.http.models import CountResult
+
     mock_client = MagicMock()
     mock_qdrant_client_class.return_value = mock_client
     knowledge_store = QdrantKnowledgeStore(
         collection_name="test collection",
     )
 
-    test_collection_info = MagicMock()
-    test_collection_info.vectors_count = 10
-
-    mock_client.get_collection.return_value = test_collection_info
+    test_count_result = CountResult(count=10)
+    mock_client.count.return_value = test_count_result
 
     # act
     res = knowledge_store.count
@@ -548,14 +548,14 @@ def test_count(
     # assert
     assert res == 10
     mock_ensure_collection_exists.assert_called_once()
-    mock_client.get_collection.assert_called_once_with(
+    mock_client.count.assert_called_once_with(
         collection_name="test collection"
     )
 
 
 @patch.object(QdrantKnowledgeStore, "_ensure_collection_exists")
 @patch("qdrant_client.QdrantClient")
-def test_count_raises_vectors_count_none_error(
+def test_count_raises_error(
     mock_qdrant_client_class: MagicMock,
     mock_ensure_collection_exists: MagicMock,
 ) -> None:
@@ -565,38 +565,7 @@ def test_count_raises_vectors_count_none_error(
         collection_name="test collection",
     )
 
-    test_collection_info = MagicMock()
-    test_collection_info.vectors_count = None
-
-    mock_client.get_collection.return_value = test_collection_info
-
-    # act
-    with pytest.raises(
-        KnowledgeStoreError,
-        match="Collection exists, but `vectors_count` is None.",
-    ):
-        knowledge_store.count
-
-    # assert
-    mock_ensure_collection_exists.assert_called_once()
-    mock_client.get_collection.assert_called_once_with(
-        collection_name="test collection"
-    )
-
-
-@patch.object(QdrantKnowledgeStore, "_ensure_collection_exists")
-@patch("qdrant_client.QdrantClient")
-def test_count_raises_collection_info_error(
-    mock_qdrant_client_class: MagicMock,
-    mock_ensure_collection_exists: MagicMock,
-) -> None:
-    mock_client = MagicMock()
-    mock_qdrant_client_class.return_value = mock_client
-    knowledge_store = QdrantKnowledgeStore(
-        collection_name="test collection",
-    )
-
-    mock_client.get_collection.side_effect = RuntimeError("mock qdrant error")
+    mock_client.count.side_effect = RuntimeError("mock qdrant error")
 
     # act
     with pytest.raises(
@@ -607,7 +576,7 @@ def test_count_raises_collection_info_error(
 
     # assert
     mock_ensure_collection_exists.assert_called_once()
-    mock_client.get_collection.assert_called_once_with(
+    mock_client.count.assert_called_once_with(
         collection_name="test collection"
     )
 


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
When trying to use `~QdrantClient.get_collection()` to get the `~qdrant_client.CollectionInfo` to get count, the vector count was being returned as `None`. After google search, Gemini recommended another api to use, in particular `~QdrantClient.count` which seems like the one we should've been using all along!

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved

