### PR TITLE
[Feature] Add `load_nodes_kwargs` param to `QdrantKnowledgeStore`

### DIFF
--- a/src/fed_rag/knowledge_stores/qdrant/sync.py
+++ b/src/fed_rag/knowledge_stores/qdrant/sync.py
@@ -78,6 +78,7 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
         description="Distance definition for collection", default="Cosine"
     )
     client_kwargs: dict[str, Any] = Field(default_factory=dict)
+    load_nodes_kwargs: dict[str, Any] = Field(default_factory=dict)
     _client: Optional["QdrantClient"] = PrivateAttr(default=None)
 
     def _collection_exists(self) -> bool:
@@ -180,7 +181,9 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
         points = [_convert_knowledge_node_to_qdrant_point(n) for n in nodes]
         try:
             self.client.upload_points(
-                collection_name=self.collection_name, points=points
+                collection_name=self.collection_name,
+                points=points,
+                **self.load_nodes_kwargs,
             )
         except Exception as e:
             raise LoadNodeError(

--- a/tests/knowledge_stores/test_qdrant.py
+++ b/tests/knowledge_stores/test_qdrant.py
@@ -22,11 +22,12 @@ from fed_rag.types.knowledge_node import KnowledgeNode
 
 def test_init() -> None:
     knowledge_store = QdrantKnowledgeStore(
-        collection_name="test collection",
+        collection_name="test collection", load_nodes_kwargs={"parallel": 4}
     )
 
     assert isinstance(knowledge_store, QdrantKnowledgeStore)
     assert knowledge_store._client is None
+    assert knowledge_store.load_nodes_kwargs == {"parallel": 4}
 
 
 def test_init_raises_error_if_qdrant_extra_is_missing_parent_import() -> None:
@@ -159,7 +160,7 @@ def test_load_nodes(mock_qdrant_client_class: MagicMock) -> None:
     mock_client = MagicMock()
     mock_qdrant_client_class.return_value = mock_client
     knowledge_store = QdrantKnowledgeStore(
-        collection_name="test collection",
+        collection_name="test collection", load_nodes_kwargs={"parallel": 4}
     )
     nodes = [
         KnowledgeNode(
@@ -183,6 +184,7 @@ def test_load_nodes(mock_qdrant_client_class: MagicMock) -> None:
     mock_client.upload_points.assert_called_once_with(
         collection_name="test collection",
         points=[_convert_knowledge_node_to_qdrant_point(n) for n in nodes],
+        parallel=4,
     )
 
     with does_not_raise():


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
Adding a plugin for users to be able to tap into the qdrant api when calling `load_nodes`. These get passed to `~QdrantClient.upload_points()` invocation.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
