### PR TITLE
[Fix] Set `timeout` param to `~qdrant_client.QdrantClient` and use contextmanager for client creation and teardown

### DIFF
--- a/src/fed_rag/exceptions/__init__.py
+++ b/src/fed_rag/exceptions/__init__.py
@@ -22,6 +22,7 @@ from .knowledge_stores import (
     InvalidDistanceError,
     KnowledgeStoreError,
     KnowledgeStoreNotFoundError,
+    KnowledgeStoreWarning,
     LoadNodeError,
 )
 from .trainer import (
@@ -62,6 +63,7 @@ __all__ = [
     "InvalidReturnType",
     # knowledge stores
     "KnowledgeStoreError",
+    "KnowledgeStoreWarning",
     "KnowledgeStoreNotFoundError",
     "InvalidDistanceError",
     "LoadNodeError",

--- a/src/fed_rag/exceptions/knowledge_stores.py
+++ b/src/fed_rag/exceptions/knowledge_stores.py
@@ -1,10 +1,16 @@
 """Exceptions for Knowledge Stores."""
 
-from .core import FedRAGError
+from .core import FedRAGError, FedRAGWarning
 
 
 class KnowledgeStoreError(FedRAGError):
     """Base knowledge store error for all knowledge-store-related exceptions."""
+
+    pass
+
+
+class KnowledgeStoreWarning(FedRAGWarning):
+    """Base knowledge store error for all knowledge-store-related warnings."""
 
     pass
 

--- a/src/fed_rag/knowledge_stores/qdrant/sync.py
+++ b/src/fed_rag/knowledge_stores/qdrant/sync.py
@@ -1,6 +1,8 @@
 """Qdrant Knowledge Store"""
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+import warnings
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Generator, Literal, Optional
 
 from pydantic import Field, PrivateAttr, SecretStr, model_validator
 
@@ -9,6 +11,7 @@ from fed_rag.exceptions import (
     InvalidDistanceError,
     KnowledgeStoreError,
     KnowledgeStoreNotFoundError,
+    KnowledgeStoreWarning,
     LoadNodeError,
 )
 from fed_rag.knowledge_stores.qdrant.utils import check_qdrant_installed
@@ -24,6 +27,7 @@ def _get_qdrant_client(
     host: str,
     port: int,
     ssl: bool = False,
+    timeout: int | None = None,
     api_key: str | None = None,
     **kwargs: Any,
 ) -> "QdrantClient":
@@ -39,7 +43,9 @@ def _get_qdrant_client(
     else:
         url = f"http://{host}:{port}"
 
-    return QdrantClient(url=url, api_key=api_key, prefer_grpc=True, **kwargs)
+    return QdrantClient(
+        url=url, api_key=api_key, prefer_grpc=True, timeout=timeout, **kwargs
+    )
 
 
 def _convert_knowledge_node_to_qdrant_point(
@@ -81,9 +87,33 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
     load_nodes_kwargs: dict[str, Any] = Field(default_factory=dict)
     _client: Optional["QdrantClient"] = PrivateAttr(default=None)
 
+    @contextmanager
+    def get_client(
+        self,
+    ) -> Generator["QdrantClient", None, None]:
+        client = _get_qdrant_client(
+            host=self.host,
+            port=self.port,
+            ssl=self.ssl,
+            api_key=self.api_key.get_secret_value() if self.api_key else None,
+            timeout=60,  # Longer timeout for heavy operations
+            **self.client_kwargs,
+        )
+
+        try:
+            yield client
+        finally:
+            try:
+                client.close()
+            except Exception as e:
+                warnings.warn(
+                    f"Unable to close client: {str(e)}", KnowledgeStoreWarning
+                )
+
     def _collection_exists(self) -> bool:
         """Check if a collection exists."""
-        return self.client.collection_exists(self.collection_name)  # type: ignore[no-any-return]
+        with self.get_client() as client:
+            return client.collection_exists(self.collection_name)  # type: ignore[no-any-return]
 
     def _create_collection(
         self, collection_name: str, vector_size: int, distance: str
@@ -100,17 +130,18 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
                 f"Mode must be one of: {', '.join([m.value for m in Distance])}"
             )
 
-        try:
-            self.client.create_collection(
-                collection_name=collection_name,
-                vectors_config=VectorParams(
-                    size=vector_size, distance=distance
-                ),
-            )
-        except Exception as e:
-            raise KnowledgeStoreError(
-                f"Failed to create collection: {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                client.create_collection(
+                    collection_name=collection_name,
+                    vectors_config=VectorParams(
+                        size=vector_size, distance=distance
+                    ),
+                )
+            except Exception as e:
+                raise KnowledgeStoreError(
+                    f"Failed to create collection: {str(e)}"
+                ) from e
 
     def _ensure_collection_exists(self) -> None:
         if not self._collection_exists():
@@ -140,35 +171,21 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
         check_qdrant_installed()
         return data
 
-    @property
-    def client(self) -> "QdrantClient":
-        if self._client is None:
-            # get and set client
-            self._client = _get_qdrant_client(
-                host=self.host,
-                port=self.port,
-                ssl=self.ssl,
-                api_key=self.api_key.get_secret_value()
-                if self.api_key
-                else None,
-                **self.client_kwargs,
-            )
-        return self._client
-
     def load_node(self, node: KnowledgeNode) -> None:
         self._check_if_collection_exists_otherwise_create_one(
             vector_size=len(node.embedding)
         )
 
         point = _convert_knowledge_node_to_qdrant_point(node)
-        try:
-            self.client.upsert(
-                collection_name=self.collection_name, points=[point]
-            )
-        except Exception as e:
-            raise LoadNodeError(
-                f"Failed to load node {node.node_id} into collection '{self.collection_name}': {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                client.upsert(
+                    collection_name=self.collection_name, points=[point]
+                )
+            except Exception as e:
+                raise LoadNodeError(
+                    f"Failed to load node {node.node_id} into collection '{self.collection_name}': {str(e)}"
+                ) from e
 
     def load_nodes(self, nodes: list[KnowledgeNode]) -> None:
         if not nodes:
@@ -179,16 +196,17 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
         )
 
         points = [_convert_knowledge_node_to_qdrant_point(n) for n in nodes]
-        try:
-            self.client.upload_points(
-                collection_name=self.collection_name,
-                points=points,
-                **self.load_nodes_kwargs,
-            )
-        except Exception as e:
-            raise LoadNodeError(
-                f"Loading nodes into collection '{self.collection_name}' failed: {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                client.upload_points(
+                    collection_name=self.collection_name,
+                    points=points,
+                    **self.load_nodes_kwargs,
+                )
+            except Exception as e:
+                raise LoadNodeError(
+                    f"Loading nodes into collection '{self.collection_name}' failed: {str(e)}"
+                ) from e
 
     def retrieve(
         self, query_emb: list[float], top_k: int
@@ -198,16 +216,17 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
 
         self._ensure_collection_exists()
 
-        try:
-            hits: QueryResponse = self.client.query_points(
-                collection_name=self.collection_name,
-                query=query_emb,
-                limit=top_k,
-            )
-        except Exception as e:
-            raise KnowledgeStoreError(
-                f"Failed to retrieve from collection '{self.collection_name}': {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                hits: QueryResponse = client.query_points(
+                    collection_name=self.collection_name,
+                    query=query_emb,
+                    limit=top_k,
+                )
+            except Exception as e:
+                raise KnowledgeStoreError(
+                    f"Failed to retrieve from collection '{self.collection_name}': {str(e)}"
+                ) from e
 
         return [
             _convert_scored_point_to_knowledge_node_and_score_tuple(pt)
@@ -226,21 +245,22 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
 
         self._ensure_collection_exists()
 
-        try:
-            res: UpdateResult = self.client.delete(
-                collection_name=self.collection_name,
-                points_selector=Filter(
-                    must=[
-                        FieldCondition(
-                            key="node_id", match=MatchValue(value=node_id)
-                        )
-                    ]
-                ),
-            )
-        except Exception:
-            raise KnowledgeStoreError(
-                f"Failed to delete node: '{node_id}' from collection '{self.collection_name}'"
-            )
+        with self.get_client() as client:
+            try:
+                res: UpdateResult = client.delete(
+                    collection_name=self.collection_name,
+                    points_selector=Filter(
+                        must=[
+                            FieldCondition(
+                                key="node_id", match=MatchValue(value=node_id)
+                            )
+                        ]
+                    ),
+                )
+            except Exception:
+                raise KnowledgeStoreError(
+                    f"Failed to delete node: '{node_id}' from collection '{self.collection_name}'"
+                )
 
         return bool(res.status == UpdateStatus.COMPLETED)
 
@@ -248,12 +268,13 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
         self._ensure_collection_exists()
 
         # delete the collection
-        try:
-            self.client.delete_collection(collection_name=self.collection_name)
-        except Exception as e:
-            raise KnowledgeStoreError(
-                f"Failed to delete collection '{self.collection_name}': {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                client.delete_collection(collection_name=self.collection_name)
+            except Exception as e:
+                raise KnowledgeStoreError(
+                    f"Failed to delete collection '{self.collection_name}': {str(e)}"
+                ) from e
 
     @property
     def count(self) -> int:
@@ -261,15 +282,16 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
 
         self._ensure_collection_exists()
 
-        try:
-            res: CountResult = self.client.count(
-                collection_name=self.collection_name
-            )
-            return int(res.count)
-        except Exception as e:
-            raise KnowledgeStoreError(
-                f"Failed to get vector count for collection '{self.collection_name}': {str(e)}"
-            ) from e
+        with self.get_client() as client:
+            try:
+                res: CountResult = client.count(
+                    collection_name=self.collection_name
+                )
+                return int(res.count)
+            except Exception as e:
+                raise KnowledgeStoreError(
+                    f"Failed to get vector count for collection '{self.collection_name}': {str(e)}"
+                ) from e
 
     def persist(self) -> None:
         """Persist a knowledge store to disk."""

--- a/src/fed_rag/knowledge_stores/qdrant/sync.py
+++ b/src/fed_rag/knowledge_stores/qdrant/sync.py
@@ -2,9 +2,9 @@
 
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generator, Literal, Optional
+from typing import TYPE_CHECKING, Any, Generator, Literal
 
-from pydantic import Field, PrivateAttr, SecretStr, model_validator
+from pydantic import Field, SecretStr, model_validator
 
 from fed_rag.base.knowledge_store import BaseKnowledgeStore
 from fed_rag.exceptions import (
@@ -85,7 +85,6 @@ class QdrantKnowledgeStore(BaseKnowledgeStore):
     )
     client_kwargs: dict[str, Any] = Field(default_factory=dict)
     load_nodes_kwargs: dict[str, Any] = Field(default_factory=dict)
-    _client: Optional["QdrantClient"] = PrivateAttr(default=None)
 
     @contextmanager
     def get_client(

--- a/tests/knowledge_stores/test_qdrant.py
+++ b/tests/knowledge_stores/test_qdrant.py
@@ -26,7 +26,6 @@ def test_init() -> None:
     )
 
     assert isinstance(knowledge_store, QdrantKnowledgeStore)
-    assert knowledge_store._client is None
     assert knowledge_store.load_nodes_kwargs == {"parallel": 4}
 
 
@@ -87,10 +86,11 @@ def test_get_qdrant_client(mock_qdrant_client_class: MagicMock) -> None:
     )
 
     # act
-    knowledge_store.client
+    with knowledge_store.get_client() as _client:
+        pass
 
     mock_qdrant_client_class.assert_called_once_with(
-        url="http://localhost:6334", api_key=None, prefer_grpc=True
+        url="http://localhost:6334", api_key=None, prefer_grpc=True, timeout=60
     )
 
 
@@ -101,10 +101,14 @@ def test_get_qdrant_client_ssl(mock_qdrant_client_class: MagicMock) -> None:
     )
 
     # act
-    knowledge_store.client
+    with knowledge_store.get_client() as _client:
+        pass
 
     mock_qdrant_client_class.assert_called_once_with(
-        url="https://localhost:6334", api_key=None, prefer_grpc=True
+        url="https://localhost:6334",
+        api_key=None,
+        prefer_grpc=True,
+        timeout=60,
     )
 
 

--- a/tests/knowledge_stores/test_qdrant.py
+++ b/tests/knowledge_stores/test_qdrant.py
@@ -9,6 +9,7 @@ from fed_rag.exceptions import (
     InvalidDistanceError,
     KnowledgeStoreError,
     KnowledgeStoreNotFoundError,
+    KnowledgeStoreWarning,
     LoadNodeError,
     MissingExtraError,
 )
@@ -110,6 +111,31 @@ def test_get_qdrant_client_ssl(mock_qdrant_client_class: MagicMock) -> None:
         prefer_grpc=True,
         timeout=60,
     )
+
+
+@patch("qdrant_client.QdrantClient")
+def test_get_qdrant_client_error_at_teardown_throws_warning(
+    mock_qdrant_client_class: MagicMock,
+) -> None:
+    knowledge_store = QdrantKnowledgeStore(
+        collection_name="test collection",
+    )
+    mock_instance = MagicMock()
+    mock_qdrant_client_class.return_value = mock_instance
+    mock_instance.close.side_effect = RuntimeError("mock error from qdrant")
+
+    # act
+    with pytest.warns(
+        KnowledgeStoreWarning,
+        match="Unable to close client: mock error from qdrant",
+    ):
+        with knowledge_store.get_client() as _client:
+            pass
+
+    mock_qdrant_client_class.assert_called_once_with(
+        url="http://localhost:6334", api_key=None, prefer_grpc=True, timeout=60
+    )
+    mock_instance.close.assert_called_once()
 
 
 @patch("qdrant_client.QdrantClient")


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
Without setting a timeout value to the client, we were getting the error below. To fix, we need to set a higher value of timeout than the global timeout. This PR sets this value to 60s.

We also change the way we create clients in this client. In particular, we use contextmanagers for creation and teardown of these clients on a per-need basis.

```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.DEADLINE_EXCEEDED
        details = "Deadline Exceeded"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_message:"Deadline Exceeded", grpc_status:4, created_time:"2025-05-09T13:38:44.531934613-04:00"}"
>
```

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [ ] Code coverage maintained or improved

