### PR TITLE
[Feature] Add `BaseBridgeMixin` to base module

### DIFF
--- a/src/fed_rag/base/bridge.py
+++ b/src/fed_rag/base/bridge.py
@@ -2,7 +2,6 @@
 
 import importlib
 import importlib.util
-from abc import ABC
 from typing import Any, ClassVar, Optional, TypedDict
 
 from pydantic import BaseModel, ConfigDict, model_validator
@@ -17,7 +16,7 @@ class BridgeMetadata(TypedDict):
     installed_version: str
 
 
-class BaseBridgeMixin(BaseModel, ABC):
+class BaseBridgeMixin(BaseModel):
     """Base Bridge Class."""
 
     # Version of the bridge implementaiton

--- a/src/fed_rag/base/bridge.py
+++ b/src/fed_rag/base/bridge.py
@@ -1,0 +1,62 @@
+"""Base Bridge"""
+
+import importlib
+import importlib.util
+from abc import ABC
+from typing import Any, ClassVar, Optional, TypedDict
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from fed_rag.exceptions import MissingExtraError
+
+
+class BridgeMetadata(TypedDict):
+    bridge_version: str
+    framework: str
+    compatible_versions: list[str]
+    installed_version: str
+
+
+class BaseBridgeMixin(BaseModel, ABC):
+    """Base Bridge Class."""
+
+    # Version of the bridge implementaiton
+    _bridge_version: ClassVar[str]
+    _bridge_extra: ClassVar[Optional[str | None]]
+    _framework: ClassVar[str]
+    _compatible_versions: ClassVar[list[str]]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def get_bridge_metadata(self) -> BridgeMetadata:
+        metadata: BridgeMetadata = {
+            "bridge_version": self._bridge_version,
+            "framework": self._framework,
+            "compatible_versions": self._compatible_versions,
+            "installed_version": self.get_installed_framework_version(),
+        }
+        return metadata
+
+    @classmethod
+    def _validate_framework_installed(cls) -> None:
+        if importlib.util.find_spec(cls._framework) is None:
+            if cls._bridge_extra:
+                missing_package_or_extra = f"fed-rag[{cls._bridge_extra}]"
+            else:
+                missing_package_or_extra = cls._framework
+            raise MissingExtraError(
+                f"{cls.__name__} requires the {cls._framework} to be installed. "
+                f"To fix please run `pip install {missing_package_or_extra}`."
+            )
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_dependencies(cls, data: Any) -> Any:
+        """Validate that qdrant dependencies are installed."""
+        cls._validate_framework_installed()
+        return data
+
+    def get_installed_framework_version(self) -> str:
+        self._validate_framework_installed()
+        module = importlib.import_module(self._framework.replace("-", "_"))
+        return getattr(module, "__version__", "unknown")

--- a/tests/bridges/test_base.py
+++ b/tests/bridges/test_base.py
@@ -1,0 +1,42 @@
+from types import ModuleType
+from unittest.mock import MagicMock, _Call, patch
+
+from fed_rag.base.bridge import BaseBridgeMixin
+
+
+class _TestBridgeMixin(BaseBridgeMixin):
+    _bridge_version = "0.1.0"
+    _bridge_extra = "my-bridge"
+    _framework = "my-bridge-framework"
+    _compatible_versions = ["0.1.x"]
+
+
+@patch.object(BaseBridgeMixin, "_validate_framework_installed")
+def test_bridge_init(mock_validate_framework_installed: MagicMock) -> None:
+    _TestBridgeMixin()
+
+    mock_validate_framework_installed.assert_called_once()
+
+
+@patch.object(BaseBridgeMixin, "_validate_framework_installed")
+@patch("fed_rag.base.bridge.importlib")
+def test_bridge_get_metadata(
+    mock_importlib: MagicMock, mock_validate_framework_installed: MagicMock
+) -> None:
+    mock_module = ModuleType("my_bridge_framework")
+    setattr(mock_module, "__version__", "0.1.1")
+    mock_importlib.import_module.return_value = mock_module
+    bridge_mixin = (
+        _TestBridgeMixin()
+    )  # not really supposed to be instantiated on own
+
+    metadata = bridge_mixin.get_bridge_metadata()
+
+    mock_validate_framework_installed.assert_has_calls(
+        [_Call(((), {})), _Call(((), {}))]
+    )
+    mock_importlib.import_module.assert_called_once_with("my_bridge_framework")
+    assert metadata["installed_version"] == "0.1.1"
+    assert metadata["bridge_version"] == "0.1.0"
+    assert metadata["compatible_versions"] == ["0.1.x"]
+    assert metadata["framework"] == "my-bridge-framework"

--- a/tests/bridges/test_base.py
+++ b/tests/bridges/test_base.py
@@ -10,7 +10,7 @@ from fed_rag.exceptions import MissingExtraError
 
 class _TestBridgeMixin(BaseBridgeMixin):
     _bridge_version = "0.1.0"
-    _bridge_extra: str | None = "my-bridge"
+    _bridge_extra = "my-bridge"
     _framework = "my-bridge-framework"
     _compatible_versions = ["0.1.x"]
 
@@ -64,5 +64,5 @@ def test_validate_framework_installed(mock_importlib_util: MagicMock) -> None:
         "To fix please run `pip install my-bridge-framework`."
     )
     with pytest.raises(MissingExtraError, match=re.escape(msg)):
-        _TestBridgeMixin._bridge_extra = None
+        _TestBridgeMixin._bridge_extra = None  # type:ignore [assignment]
         _TestBridgeMixin()


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
This PR adds the base class for our bridges to frameworks used for inference. The intention would be frameworks like LlamaIndex and LangChain would have respective bridge classes (i.e., mixins) that we'd attach to `RAGSystem`. This would give the `RAGSystem` the ability to convert the fed rag class to the appropriate one in the bridged framework.


## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [ ] Unit tests added or updated
- [ ] All tests pass locally (`make test`)
- [ ] Code coverage maintained or improved
