### PR TITLE
[Fix] Fix `LlamaIndexBridge` issue with fed-rag prompt template not playing nice with llama-index's template

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,7 +9,5 @@ overall utilty.
 
 - :material-hexagon-outline: [__RA-DIT__](./ra_dit/index.md) — A comprehensive
   reproduction of the RA-DIT method, adapted for practical demonstration.
-- :material-hexagon-outline: [__LlamaIndex__](./llamaindex/index.md) — Turn your
-  `RAGSystem` into a `~llama_index.VectorStoreIndex` and use it for inference.
 
 </div>

--- a/docs/notebooks/integrations/llama_index.ipynb
+++ b/docs/notebooks/integrations/llama_index.ipynb
@@ -1,0 +1,272 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f31024c3-3f4f-4909-94c2-ef5bc7de1f5a",
+   "metadata": {},
+   "source": [
+    "# Using LlamaIndex for Inference\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "After fine-tuning your RAG system to achieve desired performance, you'll want to\n",
+    "deploy it for inference. While FedRAG's `RAGSystem` provides complete inference\n",
+    "capabilities out of the box, you may need additional features for production deployments\n",
+    "or want to leverage the ecosystem of existing RAG frameworks.\n",
+    "\n",
+    "FedRAG offers a seamless integration into [LlamaIndex](https://github.com/run-llama/llama_index) through our bridges system,\n",
+    "giving you the best of both worlds: FedRAG's fine-tuning capabilities combined\n",
+    "with the extensive inference features of LlamaIndex.\n",
+    "\n",
+    "In this example, we demonstrate how you can convert a `RAGSystem` to a\n",
+    "`~llama_index.BaseManagedIndex` from which you can obtain `~llama_index.QueryEngine`\n",
+    "as well as `~llama_index.Retriever`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "248dec17-5225-4d16-8aad-00c0101c7a4b",
+   "metadata": {},
+   "source": [
+    "### Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65ad8f32-d63a-4b9f-8406-79130df4945e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If running in a Google Colab, the first attempt at installing fed-rag may fail,\n",
+    "# though for reasons unknown to me yet, if you try a second time, it magically works...\n",
+    "!pip install fed-rag[huggingface,llama-index] -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8db0e246-6757-4c67-98b8-347173d186b7",
+   "metadata": {},
+   "source": [
+    "## Setup — The RAG System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "edf7eae4-e5c8-4f97-8a82-a8c4ddbaea83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from transformers.generation.utils import GenerationConfig\n",
+    "\n",
+    "from fed_rag import RAGSystem, RAGConfig\n",
+    "from fed_rag.generators.huggingface import HFPretrainedModelGenerator\n",
+    "from fed_rag.retrievers.huggingface import (\n",
+    "    HFSentenceTransformerRetriever,\n",
+    ")\n",
+    "from fed_rag.knowledge_stores import InMemoryKnowledgeStore\n",
+    "from fed_rag.types import KnowledgeNode, NodeType\n",
+    "\n",
+    "\n",
+    "QUERY_ENCODER_NAME = \"nthakur/dragon-plus-query-encoder\"\n",
+    "CONTEXT_ENCODER_NAME = \"nthakur/dragon-plus-context-encoder\"\n",
+    "PRETRAINED_MODEL_NAME = \"Qwen/Qwen3-0.6B\"\n",
+    "\n",
+    "# Retriever\n",
+    "retriever = HFSentenceTransformerRetriever(\n",
+    "    query_model_name=QUERY_ENCODER_NAME,\n",
+    "    context_model_name=CONTEXT_ENCODER_NAME,\n",
+    "    load_model_at_init=False,\n",
+    ")\n",
+    "\n",
+    "# Generator\n",
+    "generation_cfg = GenerationConfig(\n",
+    "    do_sample=True,\n",
+    "    eos_token_id=151643,\n",
+    "    bos_token_id=151643,\n",
+    "    max_new_tokens=2048,\n",
+    "    top_p=0.9,\n",
+    "    temperature=0.6,\n",
+    "    cache_implementation=\"offloaded\",\n",
+    "    stop_strings=\"</response>\",\n",
+    ")\n",
+    "generator = HFPretrainedModelGenerator(\n",
+    "    model_name=\"Qwen/Qwen2.5-1.5B\",\n",
+    "    load_model_at_init=False,\n",
+    "    load_model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": torch.float16},\n",
+    "    generation_config=generation_cfg,\n",
+    ")\n",
+    "\n",
+    "# Knowledge store\n",
+    "knowledge_store = InMemoryKnowledgeStore()\n",
+    "\n",
+    "\n",
+    "# Create the RAG system\n",
+    "rag_system = RAGSystem(\n",
+    "    retriever=retriever,\n",
+    "    generator=generator,\n",
+    "    knowledge_store=knowledge_store,\n",
+    "    rag_config=RAGConfig(top_k=1),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ba2f188-5a6c-4092-834e-b45d321a1eba",
+   "metadata": {},
+   "source": [
+    "### Add some knowledge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3c13ca5a-83da-44af-9bc9-c75274856248",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_chunks = [\n",
+    "    \"Retrieval-Augmented Generation (RAG) combines retrieval with generation.\",\n",
+    "    \"LLMs can hallucinate information when they lack context.\",\n",
+    "]\n",
+    "knowledge_nodes = [\n",
+    "    KnowledgeNode(\n",
+    "        node_type=\"text\",\n",
+    "        embedding=retriever.encode_context(ct).tolist(),\n",
+    "        text_content=ct,\n",
+    "    )\n",
+    "    for ct in text_chunks\n",
+    "]\n",
+    "knowledge_store.load_nodes(knowledge_nodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6c0389b3-da82-4e37-915a-1326a4573b1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rag_system.knowledge_store.count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6df7a0b-b0f2-45b3-9cc8-c9d7d8997056",
+   "metadata": {},
+   "source": [
+    "## Using the Bridge\n",
+    "\n",
+    "Converting your RAG system to a LlamaIndex object is seamless since the bridge\n",
+    "functionality is already built into the `RAGSystem` class. The `RAGSystem` inherits\n",
+    "from `LlamaIndexBridgeMixin`, which provides the `to_llamaindex()` method for\n",
+    "effortless conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "87648b84-00a2-4bb1-b30e-07b5b9a090b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:151643 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "You are a helpful assistant. Given the user's question, provide a succinct\n",
+      "and accurate response. If context is provided, use it in your answer if it helps\n",
+      "you to create the most accurate response.\n",
+      "\n",
+      "<question>\n",
+      "Context information is below.\n",
+      "---------------------\n",
+      "LLMs can hallucinate information when they lack context.\n",
+      "---------------------\n",
+      "Given the context information and not prior knowledge, answer the query.\n",
+      "Query: What happens if LLMs lack context?\n",
+      "Answer: \n",
+      "</question>\n",
+      "\n",
+      "<context>\n",
+      "\n",
+      "</context>\n",
+      "\n",
+      "<response>\n",
+      "\n",
+      "Assistant: If LLMs lack context, they may hallucinate information, which means they generate incorrect or irrelevant information that is not based on the available context. This can lead to inaccurate results and potentially harm the user's decision-making process. To avoid this, it is important to provide LLMs with relevant and accurate context before using them. \n",
+      "\n",
+      "Score: 0.5453173113645673, Content: Node ID: 9eaf96fe-c784-4cac-b423-518e063a936b\n",
+      "Text: LLMs can hallucinate information when they lack context.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a llamaindex object\n",
+    "index = rag_system.to_llamaindex()\n",
+    "\n",
+    "# Use it like any other LlamaIndex object to get a query engine\n",
+    "query = \"What happens if LLMs lack context?\"\n",
+    "query_engine = index.as_query_engine()\n",
+    "response = query_engine.query(query)\n",
+    "print(response, \"\\n\")\n",
+    "\n",
+    "# Or, get a retriever\n",
+    "retriever = index.as_retriever()\n",
+    "results = retriever.retrieve(query)\n",
+    "for node in results:\n",
+    "    print(f\"Score: {node.score}, Content: {node.node}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9517fc89-29c0-438c-9213-e6bebc1c204a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/integrations/llama_index.ipynb
+++ b/docs/notebooks/integrations/llama_index.ipynb
@@ -20,7 +20,10 @@
     "\n",
     "In this example, we demonstrate how you can convert a `RAGSystem` to a\n",
     "`~llama_index.BaseManagedIndex` from which you can obtain `~llama_index.QueryEngine`\n",
-    "as well as `~llama_index.Retriever`."
+    "as well as `~llama_index.Retriever`.\n",
+    "\n",
+    "__NOTE:__\n",
+    "Streaming and async functionalities are not yet supported."
    ]
   },
   {
@@ -33,10 +36,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "65ad8f32-d63a-4b9f-8406-79130df4945e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zsh:1: no matches found: fed-rag[huggingface,llama-index]\n"
+     ]
+    }
+   ],
    "source": [
     "# If running in a Google Colab, the first attempt at installing fed-rag may fail,\n",
     "# though for reasons unknown to me yet, if you try a second time, it magically works...\n",
@@ -53,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "edf7eae4-e5c8-4f97-8a82-a8c4ddbaea83",
    "metadata": {},
    "outputs": [],
@@ -122,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "3c13ca5a-83da-44af-9bc9-c75274856248",
    "metadata": {},
    "outputs": [],
@@ -144,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "6c0389b3-da82-4e37-915a-1326a4573b1c",
    "metadata": {},
    "outputs": [
@@ -154,7 +165,7 @@
        "2"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,12 +184,15 @@
     "Converting your RAG system to a LlamaIndex object is seamless since the bridge\n",
     "functionality is already built into the `RAGSystem` class. The `RAGSystem` inherits\n",
     "from `LlamaIndexBridgeMixin`, which provides the `to_llamaindex()` method for\n",
-    "effortless conversion."
+    "effortless conversion.\n",
+    "\n",
+    "__NOTE__: The `to_llamaindex()` method returns a `FedRAGManagedIndex` object, which is\n",
+    "a custom implementation of the `~llama_index.BaseManagedIndex` class."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "87648b84-00a2-4bb1-b30e-07b5b9a090b5",
    "metadata": {},
    "outputs": [
@@ -186,39 +200,39 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "Sliding Window Attention is enabled but not implemented for `sdpa`; unexpected results may be encountered.\n",
       "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
-      "Setting `pad_token_id` to `eos_token_id`:151643 for open-end generation.\n"
+      "Setting `pad_token_id` to `eos_token_id`:151643 for open-end generation.\n",
+      "The attention mask is not set and cannot be inferred from input because pad token is same as eos token. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "You are a helpful assistant. Given the user's question, provide a succinct\n",
-      "and accurate response. If context is provided, use it in your answer if it helps\n",
-      "you to create the most accurate response.\n",
-      "\n",
-      "<question>\n",
       "Context information is below.\n",
       "---------------------\n",
       "LLMs can hallucinate information when they lack context.\n",
+      "\n",
+      "Retrieval-Augmented Generation (RAG) combines retrieval with generation.\n",
       "---------------------\n",
       "Given the context information and not prior knowledge, answer the query.\n",
       "Query: What happens if LLMs lack context?\n",
-      "Answer: \n",
-      "</question>\n",
+      "Answer: 1. LLMs (Language Model Generators) can hallucinate information when they lack context. This means that without sufficient information or context, LLMs may generate responses that are not based on real-world facts or previous knowledge.\n",
       "\n",
-      "<context>\n",
+      "2. LLMs are designed to generate responses based on the input provided, but when the input is incomplete or lacks context, they may fill in the gaps with their own assumptions or generate incorrect or irrelevant information.\n",
       "\n",
-      "</context>\n",
+      "3. LLMs rely on their training data and the context in which it was generated to make predictions. If the context is not present or incomplete, the LLM may generate responses that are not relevant or accurate.\n",
       "\n",
-      "<response>\n",
+      "4. LLMs can be trained on large datasets, but they still require context to understand the meaning of the input. Without context, LLMs may generate responses that are not relevant or accurate.\n",
       "\n",
-      "Assistant: If LLMs lack context, they may hallucinate information, which means they generate incorrect or irrelevant information that is not based on the available context. This can lead to inaccurate results and potentially harm the user's decision-making process. To avoid this, it is important to provide LLMs with relevant and accurate context before using them. \n",
+      "5. It is important to provide context when using LLMs to ensure that the generated responses are accurate and relevant. This can be done by providing the necessary information or context to the LLM, or by using a combination of LLMs and other tools to generate responses. \n",
       "\n",
-      "Score: 0.5453173113645673, Content: Node ID: 9eaf96fe-c784-4cac-b423-518e063a936b\n",
-      "Text: LLMs can hallucinate information when they lack context.\n"
+      "Score: 0.5453173113645673, Content: Node ID: 8864707f-9fce-49f3-aa34-7370b41bfc4f\n",
+      "Text: LLMs can hallucinate information when they lack context.\n",
+      "Score: 0.5065647593667755, Content: Node ID: eb4b722f-1e0c-4434-915c-4cd9db604dba\n",
+      "Text: Retrieval-Augmented Generation (RAG) combines retrieval with\n",
+      "generation.\n"
      ]
     }
    ],
@@ -240,12 +254,205 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "270a3335-66ec-47a3-ac2f-1592a6496b72",
+   "metadata": {},
+   "source": [
+    "### Modifying Knowledge\n",
+    "\n",
+    "In addition to querying the bridged index, you can also make changes to the\n",
+    "underlying KnowledgeStore using LlamaIndex's API:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9517fc89-29c0-438c-9213-e6bebc1c204a",
+   "execution_count": 5,
+   "id": "39707b5a-82e1-4977-be72-96ce9f6714d2",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from llama_index.core.schema import Node, MediaResource\n",
+    "\n",
+    "llama_nodes = [\n",
+    "    Node(\n",
+    "        embedding=[1, 1, 1],\n",
+    "        text_resource=MediaResource(text=\"some arbitrary text\"),\n",
+    "    ),\n",
+    "    Node(\n",
+    "        embedding=[2, 2, 2],\n",
+    "        text_resource=MediaResource(text=\"some more arbitrary text\"),\n",
+    "    ),\n",
+    "]\n",
+    "index.insert_nodes(llama_nodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ff1bb880-a526-4dd7-8751-06f08689092d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# confirm that what we added above is indeed in the knowledge store\n",
+    "rag_system.knowledge_store.count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2febaa2d-d28f-46d2-8de7-741fe28f322f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# you can also delete nodes\n",
+    "index.delete_nodes(node_ids=[node.node_id for node in llama_nodes])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "abc736ec-6dff-4c54-b145-8c65592a68c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# confirm that what we deleted above is indeed removed from the knowledge store\n",
+    "rag_system.knowledge_store.count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e77df437-2e4a-45fc-8114-d3e7e8f0c0a7",
+   "metadata": {},
+   "source": [
+    "### Advanced Usage\n",
+    "\n",
+    "You can combine your bridged index with LlamaIndex's advanced features:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6a6e4807-7fed-4466-9d5a-bd16de9a8aad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.\n",
+      "Setting `pad_token_id` to `eos_token_id`:151643 for open-end generation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Context information is below.\n",
+      "---------------------\n",
+      "Retrieval-Augmented Generation (RAG) combines retrieval with generation.\n",
+      "\n",
+      "LLMs can hallucinate information when they lack context.\n",
+      "---------------------\n",
+      "Given the context information and not prior knowledge, answer the query.\n",
+      "Query: Explain the benefits of RAG systems\n",
+      "Answer: 1. Retrieval-Augmented Generation (RAG) systems combine retrieval and generation to enhance the performance of LLMs. 2. RAG systems can provide more accurate and relevant results by leveraging external knowledge sources. 3. RAG systems can handle complex queries by breaking them down into smaller subqueries and combining the results. 4. RAG systems can improve the quality of generated text by providing context and guidance from external sources. 5. RAG systems can be used in various applications, such as search engines, chatbots, and virtual assistants, to provide better user experiences.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from llama_index.core.postprocessor import SentenceTransformerRerank\n",
+    "\n",
+    "rerank = SentenceTransformerRerank(\n",
+    "    model=\"cross-encoder/ms-marco-MiniLM-L-2-v2\", top_n=3\n",
+    ")\n",
+    "\n",
+    "query_engine = index.as_query_engine(\n",
+    "    similarity_top_k=2, node_postprocessors=[rerank]\n",
+    ")\n",
+    "\n",
+    "# Execute the query with the advanced configuration\n",
+    "response = query_engine.query(\"Explain the benefits of RAG systems\")\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0d0a097b-a14f-4b08-9447-a32f3ab29597",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[NodeWithScore(node=Node(id_='eb4b722f-1e0c-4434-915c-4cd9db604dba', embedding=None, metadata={}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, metadata_template='{key}: {value}', metadata_separator='\\n', text_resource=MediaResource(embeddings=None, data=None, text='Retrieval-Augmented Generation (RAG) combines retrieval with generation.', path=None, url=None, mimetype=None), image_resource=None, audio_resource=None, video_resource=None, text_template='{metadata_str}\\n\\n{content}'), score=-2.525338),\n",
+       " NodeWithScore(node=Node(id_='8864707f-9fce-49f3-aa34-7370b41bfc4f', embedding=None, metadata={}, excluded_embed_metadata_keys=[], excluded_llm_metadata_keys=[], relationships={}, metadata_template='{key}: {value}', metadata_separator='\\n', text_resource=MediaResource(embeddings=None, data=None, text='LLMs can hallucinate information when they lack context.', path=None, url=None, mimetype=None), image_resource=None, audio_resource=None, video_resource=None, text_template='{metadata_str}\\n\\n{content}'), score=-11.860242)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.source_nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d6d26a2-ae85-425d-81d3-bb613f25e8ad",
+   "metadata": {},
+   "source": [
+    "## Bridge Metadata\n",
+    "\n",
+    "To view the metadata of the LlamaIndex bridge, you can access the class attribute\n",
+    "`bridge` of the `RAGSystem` class, which is a dictionary object that contains the\n",
+    "`BridgeMetadata` for all of the installed bridges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "49206bb2-1fec-491d-9099-aa3b74fd181b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'llama-index': {'bridge_version': '0.1.0', 'framework': 'llama-index', 'compatible_versions': ['0.12.35'], 'method_name': 'to_llamaindex'}}\n",
+      "{'bridge_version': '0.1.0', 'framework': 'llama-index', 'compatible_versions': ['0.12.35'], 'method_name': 'to_llamaindex'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# see available bridges\n",
+    "print(RAGSystem.bridges)\n",
+    "\n",
+    "# see the LlamaIndex bridge metadata\n",
+    "print(RAGSystem.bridges[\"llama-index\"])"
+   ]
   }
  ],
  "metadata": {

--- a/docs/notebooks/integrations/llama_index.ipynb
+++ b/docs/notebooks/integrations/llama_index.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "78004a67-2dea-4da4-a87f-819fde322364",
+   "metadata": {},
+   "source": [
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/VectorInstitute/fed-rag/blob/main/docs/notebooks/integrations/llama_index.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>\n",
+    "\n",
+    "_(NOTE: if running on Colab, you will need to supply a WandB API Key in addition to your HFToken. Also, you'll need to change the runtime to a T4.)_"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f31024c3-3f4f-4909-94c2-ef5bc7de1f5a",
    "metadata": {},
    "source": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,8 @@ nav:
       - examples/llamaindex/index.md
   - Notebooks:
     - notebooks/basic_starter_hf.ipynb
+    - Integrations:
+      - notebooks/integrations/llama_index.ipynb
   - API Reference:
     - api_reference/index.md
     - Bridges:

--- a/src/fed_rag/_bridges/llamaindex/_managed_index.py
+++ b/src/fed_rag/_bridges/llamaindex/_managed_index.py
@@ -8,6 +8,7 @@ from llama_index.core.base.llms.types import (
     CompletionResponseGen,
     LLMMetadata,
 )
+from llama_index.core.constants import DEFAULT_SIMILARITY_TOP_K
 from llama_index.core.data_structs.data_structs import IndexStruct
 from llama_index.core.data_structs.struct_type import IndexStructType
 from llama_index.core.indices.managed.base import BaseManagedIndex
@@ -70,6 +71,9 @@ class FedRAGManagedIndex(BaseManagedIndex):
 
         def __init__(self, rag_system: _RAGSystem, *args: Any, **kwargs: Any):
             super().__init__(*args, **kwargs)
+            self.similiarity_top_k = kwargs.get(
+                "similarity_top_k", DEFAULT_SIMILARITY_TOP_K
+            )
             self._rag_system = rag_system
 
         def _retrieve(self, query_bundle: QueryBundle) -> list[NodeWithScore]:
@@ -77,9 +81,18 @@ class FedRAGManagedIndex(BaseManagedIndex):
 
             Currently only supports text-based queries.
             """
-            source_nodes = self._rag_system.retrieve(
-                query=query_bundle.query_str
+
+            query_emb: list[float] = self._rag_system.retriever.encode_query(
+                query_bundle.query_str
+            ).tolist()
+            raw_retrieval_result = self._rag_system.knowledge_store.retrieve(
+                query_emb=query_emb, top_k=self.similiarity_top_k
             )
+            source_nodes = [
+                SourceNode(score=el[0], node=el[1])
+                for el in raw_retrieval_result
+            ]
+
             return [
                 convert_source_node_to_llama_index_node_with_score(sn)
                 for sn in source_nodes

--- a/src/fed_rag/_bridges/llamaindex/_managed_index.py
+++ b/src/fed_rag/_bridges/llamaindex/_managed_index.py
@@ -119,7 +119,8 @@ class FedRAGManagedIndex(BaseManagedIndex):
 
         @llm_completion_callback()
         def complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
-            res = self._rag_system.generator.generate(query=prompt, context="")
+            with self.generator_for_llama() as generator:
+                res = generator.generate(query=prompt, context="")
             return CompletionResponse(text=res)
 
         @llm_completion_callback()

--- a/src/fed_rag/base/generator.py
+++ b/src/fed_rag/base/generator.py
@@ -7,6 +7,23 @@ from pydantic import BaseModel, ConfigDict
 
 from fed_rag.base.tokenizer import BaseTokenizer
 
+DEFAULT_PROMPT_TEMPLATE = """
+You are a helpful assistant. Given the user's query, provide a succinct
+and accurate response. If context is provided, use it in your answer if it helps
+you to create the most accurate response.
+
+<query>
+{query}
+</query>
+
+<context>
+{context}
+</context>
+
+<response>
+
+"""
+
 
 class BaseGenerator(BaseModel, ABC):
     """Base Generator Class."""
@@ -35,3 +52,13 @@ class BaseGenerator(BaseModel, ABC):
 
         NOTE: this is used in LM Supervised Retriever fine-tuning.
         """
+
+    @property
+    @abstractmethod
+    def prompt_template(self) -> str:
+        """Prompt template for formating query and context."""
+
+    @prompt_template.setter
+    @abstractmethod
+    def prompt_template(self, value: str) -> None:
+        """Prompt template setter."""

--- a/src/fed_rag/generators/huggingface/hf_peft_model.py
+++ b/src/fed_rag/generators/huggingface/hf_peft_model.py
@@ -25,13 +25,13 @@ from fed_rag.tokenizers.hf_pretrained_tokenizer import HFPretrainedTokenizer
 from .mixin import HuggingFaceGeneratorMixin
 
 DEFAULT_PROMPT_TEMPLATE = """
-You are a helpful assistant. Given the user's question, provide a succinct
+You are a helpful assistant. Given the user's query, provide a succinct
 and accurate response. If context is provided, use it in your answer if it helps
 you to create the most accurate response.
 
-<question>
-{question}
-</question>
+<query>
+{query}
+</query>
 
 <context>
 {context}
@@ -67,7 +67,7 @@ class HFPeftModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
         description="Optional kwargs dict for loading base model from HF. Defaults to None.",
         default_factory=dict,
     )
-    prompt_template: str = Field(description="Prompt template for RAG.")
+    _prompt_template: str = PrivateAttr(default=DEFAULT_PROMPT_TEMPLATE)
     _model: Optional["PeftModel"] = PrivateAttr(default=None)
     _tokenizer: HFPretrainedTokenizer | None = PrivateAttr(default=None)
 
@@ -91,9 +91,6 @@ class HFPeftModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
         generation_config = (
             generation_config if generation_config else GenerationConfig()
         )
-        prompt_template = (
-            prompt_template if prompt_template else DEFAULT_PROMPT_TEMPLATE
-        )
         super().__init__(
             model_name=model_name,
             base_model_name=base_model_name,
@@ -106,6 +103,9 @@ class HFPeftModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
         )
         self._tokenizer = HFPretrainedTokenizer(
             model_name=base_model_name, load_model_at_init=load_model_at_init
+        )
+        self._prompt_template = (
+            prompt_template if prompt_template else DEFAULT_PROMPT_TEMPLATE
         )
         if load_model_at_init:
             self._model = self._load_model_from_hf()
@@ -146,3 +146,11 @@ class HFPeftModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
     @tokenizer.setter
     def tokenizer(self, value: HFPretrainedTokenizer) -> None:
         self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
+
+    @prompt_template.setter
+    def prompt_template(self, value: str) -> None:
+        self._prompt_template = value

--- a/src/fed_rag/generators/huggingface/hf_pretrained_model.py
+++ b/src/fed_rag/generators/huggingface/hf_pretrained_model.py
@@ -24,13 +24,13 @@ from fed_rag.tokenizers.hf_pretrained_tokenizer import HFPretrainedTokenizer
 from .mixin import HuggingFaceGeneratorMixin
 
 DEFAULT_PROMPT_TEMPLATE = """
-You are a helpful assistant. Given the user's question, provide a succinct
+You are a helpful assistant. Given the user's query, provide a succinct
 and accurate response. If context is provided, use it in your answer if it helps
 you to create the most accurate response.
 
-<question>
-{question}
-</question>
+<query>
+{query}
+</query>
 
 <context>
 {context}
@@ -53,7 +53,7 @@ class HFPretrainedModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
         description="Optional kwargs dict for loading models from HF. Defaults to None.",
         default_factory=dict,
     )
-    prompt_template: str = Field(description="Prompt template for RAG.")
+    _prompt_template: str = PrivateAttr(default=DEFAULT_PROMPT_TEMPLATE)
     _model: Optional["PreTrainedModel"] = PrivateAttr(default=None)
     _tokenizer: HFPretrainedTokenizer | None = PrivateAttr(default=None)
 
@@ -75,17 +75,16 @@ class HFPretrainedModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
         generation_config = (
             generation_config if generation_config else GenerationConfig()
         )
-        prompt_template = (
-            prompt_template if prompt_template else DEFAULT_PROMPT_TEMPLATE
-        )
         super().__init__(
             model_name=model_name,
             generation_config=generation_config,
-            prompt_template=prompt_template,
             load_model_kwargs=load_model_kwargs if load_model_kwargs else {},
         )
         self._tokenizer = HFPretrainedTokenizer(
             model_name=model_name, load_model_at_init=load_model_at_init
+        )
+        self._prompt_template = (
+            prompt_template if prompt_template else DEFAULT_PROMPT_TEMPLATE
         )
         if load_model_at_init:
             self._model = self._load_model_from_hf()
@@ -118,3 +117,11 @@ class HFPretrainedModelGenerator(HuggingFaceGeneratorMixin, BaseGenerator):
     @tokenizer.setter
     def tokenizer(self, value: HFPretrainedTokenizer) -> None:
         self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
+
+    @prompt_template.setter
+    def prompt_template(self, value: str) -> None:
+        self._prompt_template = value

--- a/src/fed_rag/generators/huggingface/mixin.py
+++ b/src/fed_rag/generators/huggingface/mixin.py
@@ -27,7 +27,7 @@ class HuggingFaceGeneratorMixin:
         self: HFGeneratorProtocol, query: str, context: str, **kwargs: Any
     ) -> str:
         formatted_query = self.prompt_template.format(
-            question=query, context=context
+            query=query, context=context
         )
 
         # encode query

--- a/tests/bridges/conftest.py
+++ b/tests/bridges/conftest.py
@@ -129,6 +129,7 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
     def generate(self, query: str, context: str, **kwargs: Any) -> str:
         return f"mock output from '{query}' and '{context}'."
@@ -147,6 +148,14 @@ class MockGenerator(BaseGenerator):
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/bridges/conftest.py
+++ b/tests/bridges/conftest.py
@@ -157,6 +157,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/data_collators/conftest.py
+++ b/tests/data_collators/conftest.py
@@ -131,6 +131,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/data_collators/conftest.py
+++ b/tests/data_collators/conftest.py
@@ -103,9 +103,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -121,6 +122,14 @@ class MockGenerator(BaseGenerator):
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/data_collators/huggingface/conftest.py
+++ b/tests/data_collators/huggingface/conftest.py
@@ -86,6 +86,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/data_collators/huggingface/conftest.py
+++ b/tests/data_collators/huggingface/conftest.py
@@ -58,9 +58,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -69,13 +70,21 @@ class MockGenerator(BaseGenerator):
     def model(self) -> torch.nn.Module:
         return self._model
 
+    @model.setter
+    def model(self, value: torch.nn.Module) -> None:
+        self._model = value
+
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
 
     @tokenizer.setter
-    def tokenizer(self, v: Any) -> None:
-        self._tokenizer = v
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -107,9 +107,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -118,9 +119,21 @@ class MockGenerator(BaseGenerator):
     def model(self) -> torch.nn.Module:
         return self._model
 
+    @model.setter
+    def model(self, value: torch.nn.Module) -> None:
+        self._model = value
+
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -135,6 +135,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -2,8 +2,8 @@ from fed_rag.base.generator import BaseGenerator
 
 
 def test_generate(mock_generator: BaseGenerator) -> None:
-    output = mock_generator.generate("hello")
-    assert output == "mock output from 'hello'."
+    output = mock_generator.generate(query="hello", context="again")
+    assert output == "mock output from 'hello' and 'again'."
 
 
 def test_compute_target_sequence_proba(mock_generator: BaseGenerator) -> None:

--- a/tests/generators/test_hf_peft.py
+++ b/tests/generators/test_hf_peft.py
@@ -284,3 +284,21 @@ def test_huggingface_extra_missing_imported_from_parent() -> None:
 
     # restore module so to not affect other tests
     sys.modules[module_to_import] = original_module
+
+
+def test_prompt_setter() -> None:
+    # arrange
+    generator = HFPeftModelGenerator(
+        model_name="fake_name",
+        base_model_name="fake_base_name",
+        load_model_at_init=False,
+    )
+
+    # act
+    generator.prompt_template = "query: {query} and context: {context}"
+
+    # assert
+    assert (
+        generator.prompt_template.format(query="a", context="b")
+        == "query: a and context: b"
+    )

--- a/tests/generators/test_hf_pretrained.py
+++ b/tests/generators/test_hf_pretrained.py
@@ -268,3 +268,20 @@ def test_huggingface_extra_missing_imported_from_parent() -> None:
 
     # restore module so to not affect other tests
     sys.modules[module_to_import] = original_module
+
+
+def test_prompt_setter() -> None:
+    # arrange
+    generator = HFPretrainedModelGenerator(
+        model_name="fake_name",
+        load_model_at_init=False,
+    )
+
+    # act
+    generator.prompt_template = "query: {query} and context: {context}"
+
+    # assert
+    assert (
+        generator.prompt_template.format(query="a", context="b")
+        == "query: a and context: b"
+    )

--- a/tests/rag_system/conftest.py
+++ b/tests/rag_system/conftest.py
@@ -120,9 +120,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -131,9 +132,21 @@ class MockGenerator(BaseGenerator):
     def model(self) -> torch.nn.Module:
         return self._model
 
+    @model.setter
+    def model(self, value: torch.nn.Module) -> None:
+        self._model = value
+
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/rag_system/conftest.py
+++ b/tests/rag_system/conftest.py
@@ -148,6 +148,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/trainer_managers/conftest.py
+++ b/tests/trainer_managers/conftest.py
@@ -160,6 +160,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:

--- a/tests/trainer_managers/conftest.py
+++ b/tests/trainer_managers/conftest.py
@@ -132,9 +132,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -150,6 +151,14 @@ class MockGenerator(BaseGenerator):
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -104,9 +104,10 @@ def mock_tokenizer() -> BaseTokenizer:
 class MockGenerator(BaseGenerator):
     _model = torch.nn.Linear(2, 1)
     _tokenizer = MockTokenizer()
+    _prompt_template = "{query} and {context}"
 
-    def generate(self, input: str) -> str:
-        return f"mock output from '{input}'."
+    def generate(self, query: str, context: str, **kwargs: Any) -> str:
+        return f"mock output from '{query}' and '{context}'."
 
     def compute_target_sequence_proba(self, prompt: str, target: str) -> float:
         return 0.42
@@ -122,6 +123,14 @@ class MockGenerator(BaseGenerator):
     @property
     def tokenizer(self) -> MockTokenizer:
         return self._tokenizer
+
+    @tokenizer.setter
+    def tokenizer(self, value: BaseTokenizer) -> None:
+        self._tokenizer = value
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
 
 
 @pytest.fixture

--- a/tests/trainers/conftest.py
+++ b/tests/trainers/conftest.py
@@ -132,6 +132,10 @@ class MockGenerator(BaseGenerator):
     def prompt_template(self) -> str:
         return self._prompt_template
 
+    @prompt_template.setter
+    def prompt_template(self, v: str) -> None:
+        self._prompt_template = v
+
 
 @pytest.fixture
 def mock_generator() -> BaseGenerator:


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
There was an issue with the templates, where both fed-rag and llama-index's template was being applied before generating a query with the LLM. The fix is to resolve to llama-index style by temporarily setting the prompt_template of the generator to "{query}".

We also fix the retrieve method to use the `top_k_similarity` setting set in llama-index.

Finally, this PR also moves the docs/case-studies/llama-index to notebooks/llama-index.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
