### PR TITLE
Add trainer managers as a root import

### DIFF
--- a/docs/getting_started/import_patterns.md
+++ b/docs/getting_started/import_patterns.md
@@ -11,6 +11,7 @@ Import core components directly from the root:
 ```py
 from fed_rag import (
     RAGSystem,
+    RAGConfig,
     HFPretrainedModelGenerator,
     HFSentenceTransformerRetriever,
     InMemoryKnowledgeStore,
@@ -21,6 +22,7 @@ system = RAGSystem(
     retriever=HFSentenceTransformerRetriever(...),
     generator=HFPretrainedModelGenerator(...),
     knowledge_store=InMemoryKnowledgeStore(),
+    rag_config=RAGConfig(...),
 )
 ```
 

--- a/src/fed_rag/__init__.py
+++ b/src/fed_rag/__init__.py
@@ -13,6 +13,8 @@ from .knowledge_stores import *
 from .knowledge_stores import __all__ as _knowledge_stores_all
 from .retrievers import *
 from .retrievers import __all__ as _retrievers_all
+from .trainer_managers import *
+from .trainer_managers import __all__ as _trainer_managers_all
 
 __version__ = VERSION
 
@@ -22,5 +24,6 @@ __all__ = sorted(
     + _generators_all
     + _knowledge_stores_all
     + _retrievers_all
+    + _trainer_managers_all
     + ["RAGConfig"]
 )

--- a/src/fed_rag/trainer_managers/__init__.py
+++ b/src/fed_rag/trainer_managers/__init__.py
@@ -1,0 +1,6 @@
+"""Public RAG Trainer Managers API"""
+
+from .huggingface import HuggingFaceRAGTrainerManager
+from .pytorch import PyTorchRAGTrainerManager
+
+__all__ = ["HuggingFaceRAGTrainerManager", "PyTorchRAGTrainerManager"]


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [x] Other (please describe):

## Description
This PR allows users to import `RAGTrainerManagers` from root.

```python
from fed_rag import HuggingFaceRAGTrainerManager
```

