### PR TITLE
[Feature] Enable streaming for `BaseBenchmark` with `.as_stream()` and implement with HF mixin

### DIFF
--- a/src/fed_rag/base/evals/benchmark.py
+++ b/src/fed_rag/base/evals/benchmark.py
@@ -1,7 +1,7 @@
 """Base Benchmark and Benchmarker"""
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterator, Sequence
+from typing import Any, Generator, Iterator, Sequence
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
@@ -14,10 +14,6 @@ class BaseBenchmark(BaseModel, ABC):
     _examples: Sequence[BenchmarkExample] = PrivateAttr()
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @abstractmethod
-    def _get_examples(self, **kwargs: Any) -> Sequence[BenchmarkExample]:
-        """Method to get examples."""
 
     # give it a sequence interface for accessing examples more easily
     def __getitem__(self, index: int) -> BenchmarkExample:
@@ -34,3 +30,12 @@ class BaseBenchmark(BaseModel, ABC):
     def set_examples(self) -> "BaseBenchmark":
         self._examples = self._get_examples()
         return self
+
+    # abstractmethods
+    @abstractmethod
+    def _get_examples(self, **kwargs: Any) -> Sequence[BenchmarkExample]:
+        """Method to get examples."""
+
+    @abstractmethod
+    def as_stream(self) -> Generator[BenchmarkExample, None, None]:
+        """Produce a stream of `BenchmarkExamples`."""

--- a/src/fed_rag/evals/benchmarks/huggingface/mixin.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mixin.py
@@ -80,10 +80,15 @@ class HuggingFaceBenchmarkMixin(BaseModel, ABC):
 
     # Provide required implementations for ~BaseBenchmark
     def _get_examples(self, **kwargs: Any) -> Sequence[BenchmarkExample]:
-        return [
-            BenchmarkExample.model_validate(el)
-            for el in self.dataset[BENCHMARK_EXAMPLE_JSON_KEY]
-        ]
+        from datasets import Dataset
+
+        if isinstance(self.dataset, Dataset):
+            return [
+                BenchmarkExample.model_validate(el)
+                for el in self.dataset[BENCHMARK_EXAMPLE_JSON_KEY]
+            ]
+        else:
+            return []  # examples should be streamed
 
     def as_stream(self) -> Generator[BenchmarkExample, None, None]:
         from datasets import IterableDataset

--- a/src/fed_rag/evals/benchmarks/huggingface/mixin.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mixin.py
@@ -1,14 +1,22 @@
 """HuggingFaceBenchmarkMixin"""
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generator,
+    Optional,
+    Sequence,
+    Union,
+)
 
 from pydantic import BaseModel, PrivateAttr
 
 from fed_rag.data_structures.evals import BenchmarkExample
 
 if TYPE_CHECKING:  # pragma: no cover
-    from datasets import Dataset
+    from datasets import Dataset, IterableDataset
 
 
 BENCHMARK_EXAMPLE_JSON_KEY = "__benchmark_example_json"
@@ -49,7 +57,7 @@ class HuggingFaceBenchmarkMixin(BaseModel, ABC):
         }
         return example
 
-    def _load_dataset(self) -> "Dataset":
+    def _load_dataset(self) -> Union["Dataset", "IterableDataset"]:
         from datasets import load_dataset
 
         loaded_dataset = load_dataset(
@@ -61,19 +69,35 @@ class HuggingFaceBenchmarkMixin(BaseModel, ABC):
         )
 
         # add BenchmarkExample to dataset
-        return loaded_dataset.map(
-            self._map_dataset_example, cache_file_name=None
-        )
+        return loaded_dataset.map(self._map_dataset_example)
 
     @property
-    def dataset(self) -> "Dataset":
+    def dataset(self) -> Union["Dataset", "IterableDataset"]:
         if self._dataset is None:
             self._dataset = self._load_dataset()
 
         return self._dataset
 
+    # Provide required implementations for ~BaseBenchmark
     def _get_examples(self, **kwargs: Any) -> Sequence[BenchmarkExample]:
         return [
             BenchmarkExample.model_validate(el)
             for el in self.dataset[BENCHMARK_EXAMPLE_JSON_KEY]
         ]
+
+    def as_stream(self) -> Generator[BenchmarkExample, None, None]:
+        from datasets import IterableDataset
+
+        # check if dataset is an iterable one
+        if isinstance(self.dataset, IterableDataset):
+            iterable_dataset = self.dataset
+        else:
+            iterable_dataset = self.dataset.to_iterable_dataset()
+
+        # map the iterable_dataset to get the examples i
+        iterable_dataset = iterable_dataset.map(self._map_dataset_example)
+
+        for hf_example in iterable_dataset:
+            yield BenchmarkExample.model_validate(
+                hf_example[BENCHMARK_EXAMPLE_JSON_KEY]
+            )

--- a/tests/evals/benchmarks/_benchmarks.py
+++ b/tests/evals/benchmarks/_benchmarks.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any, Generator, Sequence
 
 from fed_rag.base.evals.benchmark import BaseBenchmark
 from fed_rag.data_structures import BenchmarkExample
@@ -18,6 +18,9 @@ class TestBenchmark(BaseBenchmark):
             BenchmarkExample(query="query 2", response="response 2"),
             BenchmarkExample(query="query 3", response="response 3"),
         ]
+
+    def as_stream(self) -> Generator[BenchmarkExample, None, None]:
+        raise NotImplementedError
 
 
 class TestHFBenchmark(HuggingFaceBenchmarkMixin, BaseBenchmark):

--- a/tests/evals/benchmarks/_benchmarks.py
+++ b/tests/evals/benchmarks/_benchmarks.py
@@ -20,7 +20,8 @@ class TestBenchmark(BaseBenchmark):
         ]
 
     def as_stream(self) -> Generator[BenchmarkExample, None, None]:
-        raise NotImplementedError
+        for ex in self._get_examples():
+            yield ex
 
 
 class TestHFBenchmark(HuggingFaceBenchmarkMixin, BaseBenchmark):

--- a/tests/evals/benchmarks/huggingface/conftest.py
+++ b/tests/evals/benchmarks/huggingface/conftest.py
@@ -1,5 +1,7 @@
+from typing import Any, Generator
+
 import pytest
-from datasets import Dataset, DatasetInfo, Split
+from datasets import Dataset, DatasetInfo, IterableDataset, Split
 
 
 @pytest.fixture
@@ -26,6 +28,28 @@ def dummy_dataset() -> Dataset:
         split=Split.TEST,
     )
     return benchmark
+
+
+@pytest.fixture
+def dummy_iterable_dataset() -> IterableDataset:
+    def example_gen() -> Generator[dict[str, Any], None, None]:
+        yield {
+            "query": "a query",
+            "response": "response to a query",
+            "context": "context for a query",
+        }
+        yield {
+            "query": "another query",
+            "response": "another response to another query",
+            "context": "another context for another query",
+        }
+        yield {
+            "query": "yet another query",
+            "response": "yet another response to yet another query",
+            "context": "yet another context for yet another query",
+        }
+
+    return IterableDataset.from_generator(example_gen, split=Split.TEST)
 
 
 @pytest.fixture

--- a/tests/evals/benchmarks/huggingface/test_mixin.py
+++ b/tests/evals/benchmarks/huggingface/test_mixin.py
@@ -20,3 +20,14 @@ def test_hf_mixin(
         == test_hf_benchmark._dataset.info.dataset_name
     )
     assert isinstance(test_hf_benchmark[0], BenchmarkExample)
+
+
+@patch("datasets.load_dataset")
+def test_hf_streaming(
+    mock_load_dataset: MagicMock, dummy_dataset: Dataset
+) -> None:
+    mock_load_dataset.return_value = dummy_dataset
+    test_hf_benchmark = benchmarks.TestHFBenchmark(streaming=True)
+
+    example_stream = test_hf_benchmark.as_stream()
+    print(next(example_stream).model_dump())

--- a/tests/evals/benchmarks/huggingface/test_mixin.py
+++ b/tests/evals/benchmarks/huggingface/test_mixin.py
@@ -38,3 +38,25 @@ def test_hf_streaming(
     next(example_stream)
     with pytest.raises(StopIteration):
         next(example_stream)
+
+
+@patch("datasets.load_dataset")
+def test_hf_convert_to_streaming(
+    mock_load_dataset: MagicMock,
+    dummy_dataset: Dataset,
+    dummy_iterable_dataset: IterableDataset,
+) -> None:
+    mock_load_dataset.return_value = dummy_dataset
+    mock_to_iterable_dataset = MagicMock()
+    mock_to_iterable_dataset.return_value = dummy_iterable_dataset
+    dummy_dataset.to_iterable_dataset = mock_to_iterable_dataset
+    test_hf_benchmark = benchmarks.TestHFBenchmark()
+
+    assert isinstance(test_hf_benchmark.dataset, Dataset)
+
+    example_stream = test_hf_benchmark.as_stream()
+    next(example_stream)
+    next(example_stream)
+    next(example_stream)
+    with pytest.raises(StopIteration):
+        next(example_stream)

--- a/tests/evals/benchmarks/test_benchmarker.py
+++ b/tests/evals/benchmarks/test_benchmarker.py
@@ -144,3 +144,21 @@ def test_benchmarker_max_reversed(mock_rag_system: RAGSystem) -> None:
     assert result.num_examples_used == 3
     assert result.num_total_examples == 3
     assert result.metric_name == "MyMetric"
+
+
+def test_benchmarker_with_streaming_avg(mock_rag_system: RAGSystem) -> None:
+    # arrange
+    test_benchmark = benchmarks.TestBenchmark()
+    benchmarker = Benchmarker(rag_system=mock_rag_system)
+    metric = MyMetric()
+
+    # act
+    result = benchmarker.run(
+        benchmark=test_benchmark, metric=metric, agg="avg", is_streaming=True
+    )
+
+    # assert
+    assert result.score == 2
+    assert result.num_examples_used == 3
+    assert result.num_total_examples == 3
+    assert result.metric_name == "MyMetric"


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
Adds streaming capabilities for `BaseBenchmark` via `.as_stream()` and correspondingly, the ability to invoke `Benchmarker.run()` when the `BaseBenchmark` is streaming.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
