### PR TITLE
[Fix] Fix codification of response in `HuggingFaceMMLU` benchmark.

### DIFF
--- a/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
@@ -1,6 +1,6 @@
 """MMLU benchmark"""
 
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import model_validator
 
@@ -28,6 +28,7 @@ class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
 
     dataset_name = "cais/mmlu"
     configuration_name: str = "all"
+    response_key: ClassVar[dict[int, str]] = {0: "A", 1: "B", 2: "C", 3: "D"}
 
     def _get_query_from_example(self, example: dict[str, Any]) -> str:
         choices = example["choices"]
@@ -35,7 +36,7 @@ class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
         return f"{example['question']}\n\n{formatted_choices}"
 
     def _get_response_from_example(self, example: dict[str, Any]) -> str:
-        return str(example["answer"])
+        return self.response_key[example["answer"]]
 
     def _get_context_from_example(self, example: dict[str, Any]) -> str | None:
         return None

--- a/tests/evals/benchmarks/huggingface/conftest.py
+++ b/tests/evals/benchmarks/huggingface/conftest.py
@@ -70,7 +70,7 @@ def dummy_mmlu() -> Dataset:
                     "The second and third pharyngeal arches",
                 ]
             ],
-            "answer": ["D"],
+            "answer": [3],
         },
         info=benchmark_info,
         split=Split.TEST,


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
The `cais/mmlu` dataset returns an answer that is in [0,1,2,3] rather then [A,B,C,D]. This PR correct the logic in `HuggingFaceMMLU._get_response_from_example()`.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
