### PR TITLE
[Fix] Make HF generators return newly generated tokens only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - ...
 
+### Changed
+
+- Fix bug in `HuggingFaceGeneratorMixin.generate()` to return newly generated tokens only (#345)
+
 ## [0.0.21] - 2025-05-23
 
 ### Changed

--- a/src/fed_rag/generators/huggingface/mixin.py
+++ b/src/fed_rag/generators/huggingface/mixin.py
@@ -45,6 +45,9 @@ class HuggingFaceGeneratorMixin:
             **kwargs,
         )
 
+        # skip the input tokens
+        generated_ids = generated_ids[:, inputs.shape[-1] :]
+
         # decode tokens
         outputs: list[str] = self.tokenizer.unwrapped.batch_decode(
             generated_ids, skip_special_tokens=True

--- a/tests/generators/test_hf_peft.py
+++ b/tests/generators/test_hf_peft.py
@@ -179,7 +179,7 @@ def test_generate() -> None:
     mock_tokenizer = MagicMock()
     mock_model = MagicMock()
     mock_model.device = torch.device("cpu")
-    mock_model.generate.return_value = torch.Tensor([1, 2, 3])
+    mock_model.generate.return_value = torch.Tensor([[1, 2, 3]])
     mock_tokenizer_result = MagicMock()
     mock_tokenizer_result.input_ids = torch.ones(2)
     mock_tokenizer.batch_decode.return_value = ["Mock output"]

--- a/tests/generators/test_hf_pretrained.py
+++ b/tests/generators/test_hf_pretrained.py
@@ -164,7 +164,7 @@ def test_generate() -> None:
     mock_tokenizer = MagicMock()
     mock_model = MagicMock()
     mock_model.device = torch.device("cpu")
-    mock_model.generate.return_value = torch.Tensor([1, 2, 3])
+    mock_model.generate.return_value = torch.Tensor([[1, 2, 3]])
     mock_tokenizer_result = MagicMock()
     mock_tokenizer_result.input_ids = torch.ones(2)
     mock_tokenizer.batch_decode.return_value = ["Mock output"]


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
Any information reviewers should be aware of:

Fixes a bug in `HuggingFaceGeneratorMixin.generate()` to return newly generated tokens only.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved

## Checklist

Before submitting your PR, please check off the following:

- [x] My code follows the existing style and conventions
- [x] I’ve run linting (`make lint`)
- [ ] I’ve added/updated relevant documentation
- [x] I’ve added/updated tests as needed
- [ ] I’ve verified integration with existing tools (HuggingFace, LlamaIndex, LangChain, etc. if applicable)
- [x] I’ve added an entry to the CHANGELOG.md (if applicable)

## Related Issues or PRs

If this PR addresses or relates to existing issues or pull requests, link them here:

- Closes #345 
- Related to #
