### PR TITLE
Feature/364 onboard more benchmarks

### DIFF
--- a/docs/api_reference/evals/benchmarks/huggingface/hotpotqa.md
+++ b/docs/api_reference/evals/benchmarks/huggingface/hotpotqa.md
@@ -1,0 +1,6 @@
+# HotPotQA
+
+::: src.fed_rag.evals.benchmarks.huggingface.hotpotqa
+    options:
+      members:
+        - HuggingFaceHotPotQA

--- a/src/fed_rag/evals/benchmarks/huggingface/__init__.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/__init__.py
@@ -1,3 +1,5 @@
+from .boolq import HuggingFaceBoolQ
+from .hellaswag import HuggingFaceHellaSwag
 from .hotpotqa import HuggingFaceHotpotQA
 from .mixin import HuggingFaceBenchmarkMixin
 from .mmlu import HuggingFaceMMLU
@@ -12,4 +14,6 @@ __all__ = [
     "HuggingFaceHotpotQA",
     "HuggingFaceSQuADv2",
     "HuggingFaceNaturalQuestions",
+    "HuggingFaceBoolQ",
+    "HuggingFaceHellaSwag",
 ]

--- a/src/fed_rag/evals/benchmarks/huggingface/__init__.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/__init__.py
@@ -1,11 +1,15 @@
 from .hotpotqa import HuggingFaceHotpotQA
 from .mixin import HuggingFaceBenchmarkMixin
 from .mmlu import HuggingFaceMMLU
+from .natrual_questions import HuggingFaceNaturalQuestions
 from .pubmedqa import HuggingFacePubMedQA
+from .squad_v2 import HuggingFaceSQuADv2
 
 __all__ = [
     "HuggingFaceBenchmarkMixin",
     "HuggingFaceMMLU",
     "HuggingFacePubMedQA",
     "HuggingFaceHotpotQA",
+    "HuggingFaceSQuADv2",
+    "HuggingFaceNaturalQuestions",
 ]

--- a/src/fed_rag/evals/benchmarks/huggingface/__init__.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/__init__.py
@@ -1,3 +1,4 @@
+from .hotpotqa import HuggingFaceHotpotQA
 from .mixin import HuggingFaceBenchmarkMixin
 from .mmlu import HuggingFaceMMLU
 from .pubmedqa import HuggingFacePubMedQA
@@ -6,4 +7,5 @@ __all__ = [
     "HuggingFaceBenchmarkMixin",
     "HuggingFaceMMLU",
     "HuggingFacePubMedQA",
+    "HuggingFaceHotpotQA",
 ]

--- a/src/fed_rag/evals/benchmarks/huggingface/boolq.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/boolq.py
@@ -1,0 +1,42 @@
+"""BoolQ benchmark"""
+
+from typing import Any
+
+from pydantic import model_validator
+
+from fed_rag.base.evals.benchmark import BaseBenchmark
+
+from .mixin import HuggingFaceBenchmarkMixin
+from .utils import check_huggingface_evals_installed
+
+
+class HuggingFaceBoolQ(HuggingFaceBenchmarkMixin, BaseBenchmark):
+    """HuggingFace BoolQ Benchmark.
+
+    BoolQ is a question answering dataset for yes/no questions about a short passage.
+
+    Example schema:
+        {
+            "question": "does ethanol take more energy make that produces",
+            "answer": false,
+            "passage": "\"All biomass goes through at least some of these steps: ...",
+        }
+    """
+
+    dataset_name = "google/boolq"
+
+    def _get_query_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["question"])
+
+    def _get_response_from_example(self, example: dict[str, Any]) -> str:
+        # Return as string "true"/"false" for consistency
+        return "true" if example["answer"] else "false"
+
+    def _get_context_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["passage"])
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_extra_installed(cls, data: Any) -> Any:
+        check_huggingface_evals_installed(cls.__name__)
+        return data

--- a/src/fed_rag/evals/benchmarks/huggingface/hellaswag.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/hellaswag.py
@@ -1,0 +1,63 @@
+"""HellaSwag benchmark."""
+
+from typing import Any
+
+from pydantic import model_validator
+
+from fed_rag.base.evals.benchmark import BaseBenchmark
+
+from .mixin import HuggingFaceBenchmarkMixin
+from .utils import check_huggingface_evals_installed
+
+
+class HuggingFaceHellaSwag(HuggingFaceBenchmarkMixin, BaseBenchmark):
+    """HuggingFace HellaSwag Benchmark.
+
+    HellaSwag is a commonsense reasoning dataset where each example consists of a context
+    and four possible endings. The task is to pick the most plausible ending.
+
+    Example schema:
+        {
+            "ind": 4,
+            "activity_label": "Removing ice from car",
+            "ctx_a": "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles.",
+            "ctx_b": "then",
+            "ctx": "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles. then",
+            "endings": [
+                ", the man adds wax to the windshield and cuts it.",
+                ", a person board a ski lift, while two men supporting the head of the person wearing winter clothes snow as the we girls sled.",
+                ", the man puts on a christmas coat, knitted with netting.",
+                ", the man continues removing the snow on his car."
+            ],
+            "source_id": "activitynet~v_-1IBHYS3L-Y",
+            "split": "train",
+            "split_type": "indomain",
+            "label": "3"
+        }
+    """
+
+    dataset_name = "Rowan/hellaswag"
+
+    def _get_query_from_example(self, example: dict[str, Any]) -> str:
+        # Use the full context for the prompt
+        return str(example["ctx"])
+
+    def _get_response_from_example(self, example: dict[str, Any]) -> str:
+        # The correct ending index as string or int
+        return str(example["label"])
+
+    def _get_context_from_example(self, example: dict[str, Any]) -> str:
+        # Show the four endings as context (choices)
+        if "endings" in example and isinstance(example["endings"], list):
+            return "\n".join(
+                f"{i}: {ending.strip()}"
+                for i, ending in enumerate(example["endings"])
+            )
+        return ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_extra_installed(cls, data: Any) -> Any:
+        """Validate that huggingface-evals dependencies are installed."""
+        check_huggingface_evals_installed(cls.__name__)
+        return data

--- a/src/fed_rag/evals/benchmarks/huggingface/hotpotqa.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/hotpotqa.py
@@ -1,0 +1,89 @@
+"""HotpotQA benchmark"""
+
+from typing import Any
+
+from pydantic import model_validator
+
+from fed_rag.base.evals.benchmark import BaseBenchmark
+
+from .mixin import HuggingFaceBenchmarkMixin
+from .utils import check_huggingface_evals_installed
+
+
+class HuggingFaceHotpotQA(HuggingFaceBenchmarkMixin, BaseBenchmark):
+    """HuggingFace HotpotQA Benchmark.
+
+    HotpotQA is a multi-hop question answering dataset that requires reasoning
+    over multiple paragraphs to answer questions.
+
+    Example schema:
+        {
+            "id": "5a7a06935542990198eaf050",
+            "question": "Which magazine was started first Arthur's Magazine or First for Women?",
+            "answer": "Arthur's Magazine",
+            "type": "comparison",
+            "level": "medium",
+            "supporting_facts": {
+                "title": ["Arthur's Magazine", "First for Women"],
+                "sent_id": [0, 0]
+            },
+            "context": {
+                "title": [
+                    "Radio City (Indian radio station)",
+                    "History of Albanian football",
+                    "Echosmith",
+                    "Women's colleges in the Southern United States",
+                    "First Arthur County Courthouse and Jail",
+                    "Arthur's Magazine",
+                    "2012–13 Ukrainian Hockey Championship",
+                    "First for Women",
+                    "Freeway Complex Fire",
+                    "William Rast"
+                ],
+                "sentences": [
+                    ["Radio City is India's first private FM...", "It plays Hindi..."],
+                    ["Football in Albania existed before...", "The Albanian..."],
+                    ...
+                    ["Arthur's Magazine (1844–1846) was an American literary periodical...", "It was founded by..."],
+                    ...
+                    ["First for Women is a woman's magazine published by...", "The magazine was started in 1989."],
+                    ...
+                ]
+            }
+        }
+    """
+
+    dataset_name = "hotpot_qa/hotpot_qa"
+    configuration_name: str = "distractor"
+
+    def _get_query_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["question"])
+
+    def _get_response_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["answer"])
+
+    def _get_context_from_example(self, example: dict[str, Any]) -> str | None:
+        context = example.get("context", {})
+        if isinstance(context, dict):
+            titles = context.get("title", [])
+            sentences = context.get("sentences", [])
+
+            # Build context by combining titles with their sentences
+            context_parts = []
+            for i, (title, sents) in enumerate(zip(titles, sentences)):
+                if isinstance(sents, list):
+                    context_parts.append(f"{title}: {' '.join(sents)}")
+                else:
+                    context_parts.append(f"{title}: {sents}")
+
+            return " ".join(context_parts) if context_parts else None
+        else:
+            # If context is not a dict, return None
+            return None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_extra_installed(cls, data: Any) -> Any:
+        """Validate that huggingface-evals dependencies are installed."""
+        check_huggingface_evals_installed(cls.__name__)
+        return data

--- a/src/fed_rag/evals/benchmarks/huggingface/natrual_questions.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/natrual_questions.py
@@ -1,0 +1,144 @@
+"""Natural Questions benchmark"""
+
+from typing import Any
+
+from pydantic import model_validator
+
+from fed_rag.base.evals.benchmark import BaseBenchmark
+
+from .mixin import HuggingFaceBenchmarkMixin
+from .utils import check_huggingface_evals_installed
+
+
+class HuggingFaceNaturalQuestions(HuggingFaceBenchmarkMixin, BaseBenchmark):
+    """HuggingFace Natural Questions Benchmark.
+
+    Natural Questions is a question answering dataset containing real user
+    questions issued to Google search, paired with Wikipedia articles containing
+    the answer. Each question may have a long answer (a paragraph) and/or a
+    short answer (a span within the paragraph).
+
+    Example schema:
+        {
+            "id": "5225754983651766092",
+            "document": {
+                "title": "Trade wind",
+                "url": "https://en.wikipedia.org/wiki/Trade_wind",
+                "html": "<!DOCTYPE html>...",
+                "tokens": {
+                    "token": ["Trade", "winds", "are", "the", "pattern", "of", "easterly", "surface", "winds", ...],
+                    "is_html": [False, False, False, False, False, False, False, False, False, ...],
+                    "start_byte": [0, 6, 12, 16, 20, 28, 30, 38, 46, ...],
+                    "end_byte": [5, 11, 15, 19, 27, 29, 37, 45, 51, ...]
+                }
+            },
+            "question": {
+                "text": "what purpose did seasonal monsoon winds have on trade",
+                "tokens": ["what", "purpose", "did", "seasonal", "monsoon", "winds", "have", "on", "trade"]
+            },
+            "long_answer_candidates": {
+                "start_byte": [43178, 44667, 48014, 49619, 50365, 52946, 54877, 56067, 57202, 58657],
+                "end_byte": [44666, 45901, 49618, 50364, 50993, 54876, 56066, 56879, 58656, 60294],
+                "start_token": [44, 161, 343, 547, 628, 749, 949, 1046, 1141, 1304],
+                "end_token": [161, 285, 547, 628, 701, 949, 1046, 1134, 1304, 1488],
+                "top_level": [True, True, True, True, True, True, True, True, True, True]
+            },
+            "annotations": {
+                "id": ["4323936797498927989", "13037645000009169623", "4439059471919323171", "15051359051424338858", "5332861748513580580"],
+                "long_answer": [
+                    {"candidate_index": -1, "start_byte": -1, "end_byte": -1, "start_token": -1, "end_token": -1},
+                    {"candidate_index": -1, "start_byte": -1, "end_byte": -1, "start_token": -1, "end_token": -1},
+                    {"candidate_index": -1, "start_byte": -1, "end_byte": -1, "start_token": -1, "end_token": -1},
+                    {"candidate_index": 0, "start_byte": 43178, "end_byte": 44666, "start_token": 44, "end_token": 161},
+                    {"candidate_index": 0, "start_byte": 43178, "end_byte": 44666, "start_token": 44, "end_token": 161}
+                ],
+                "short_answers": [
+                    {"start_byte": [], "end_byte": [], "start_token": [], "end_token": [], "text": []},
+                    {"start_byte": [], "end_byte": [], "start_token": [], "end_token": [], "text": []},
+                    {"start_byte": [], "end_byte": [], "start_token": [], "end_token": [], "text": []},
+                    {"start_byte": [44318], "end_byte": [44657], "start_token": [140], "end_token": [159],
+                     "text": ["enabled European empire expansion into the Americas and trade routes to become established across the Atlantic and Pacific oceans"]},
+                    {"start_byte": [], "end_byte": [], "start_token": [], "end_token": [], "text": []}
+                ],
+                "yes_no_answer": [-1, -1, -1, -1, -1]
+            }
+        }
+    """
+
+    dataset_name = "google-research-datasets/natural_questions"
+    configuration_name: str = "default"
+    split: str = (
+        "validation"  # Natural Questions uses 'validation' instead of 'test'
+    )
+
+    def _get_query_from_example(self, example: dict[str, Any]) -> str:
+        question = example.get("question", {})
+        return str(question.get("text", ""))
+
+    def _get_response_from_example(self, example: dict[str, Any]) -> str:
+        annotations = example.get("annotations", {})
+
+        # Get the lists from annotations
+        yes_no_answers = annotations.get("yes_no_answer", [])
+        short_answers_list = annotations.get("short_answers", [])
+        long_answers_list = annotations.get("long_answer", [])
+
+        if (
+            not yes_no_answers
+            and not short_answers_list
+            and not long_answers_list
+        ):
+            return "[NO ANSWER]"
+
+        # Check each annotation for valid answers
+        for i, yes_no_answer in enumerate(yes_no_answers):
+            # Check for yes/no answer first (-1 means no yes/no answer)
+            if yes_no_answer == 1:
+                return "YES"
+            elif yes_no_answer == 0:
+                return "NO"
+
+            # Check for short answers
+            if i < len(short_answers_list):
+                short_answer = short_answers_list[i]
+                texts = short_answer.get("text", [])
+                if texts:  # If there are short answer texts
+                    # Join multiple short answers with "and"
+                    return " and ".join(str(text) for text in texts if text)
+
+            # Check for long answers
+            if i < len(long_answers_list):
+                long_answer = long_answers_list[i]
+                if long_answer.get("candidate_index", -1) >= 0:
+                    return "[LONG ANSWER EXISTS]"
+
+        return "[NO ANSWER]"
+
+    def _get_context_from_example(self, example: dict[str, Any]) -> str | None:
+        document = example.get("document", {})
+
+        # Extract clean text from tokens (excluding HTML tags)
+        tokens = document.get("tokens", {})
+        token_list = tokens.get("token", [])
+        is_html_list = tokens.get("is_html", [])
+
+        if token_list and is_html_list:
+            # Filter out HTML tokens and join text tokens
+            text_tokens = [
+                token
+                for token, is_html in zip(token_list, is_html_list)
+                if not is_html
+            ]
+            if text_tokens:
+                return " ".join(text_tokens)
+
+        # Fallback to title as minimal context
+        title = document.get("title", "")
+        return title if title else None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_extra_installed(cls, data: Any) -> Any:
+        """Validate that huggingface-evals dependencies are installed."""
+        check_huggingface_evals_installed(cls.__name__)
+        return data

--- a/src/fed_rag/evals/benchmarks/huggingface/squad_v2.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/squad_v2.py
@@ -1,0 +1,67 @@
+"""SQuAD 2.0 benchmark"""
+
+from typing import Any
+
+from pydantic import model_validator
+
+from fed_rag.base.evals.benchmark import BaseBenchmark
+
+from .mixin import HuggingFaceBenchmarkMixin
+from .utils import check_huggingface_evals_installed
+
+
+class HuggingFaceSQuADv2(HuggingFaceBenchmarkMixin, BaseBenchmark):
+    """HuggingFace SQuAD 2.0 Benchmark.
+
+    Stanford Question Answering Dataset (SQuAD) 2.0 combines 100,000 questions
+    from SQuAD 1.1 with over 50,000 unanswerable questions. Systems must not
+    only answer questions when possible, but also determine when no answer is
+    supported by the paragraph.
+
+    Example schema:
+        {
+            "id": "56ddde2d66d3e219004dad4d",
+            "title": "Symbiosis",
+            "context": "Symbiotic relationships include those associations in which one organism lives on another (ectosymbiosis, such as...",
+            "question": "What is an example of ectosymbiosis?",
+            "answers": {
+                "text": ["mistletoe"],
+                "answer_start": [114]
+            }
+        }
+
+    For unanswerable questions, the answers field has empty lists:
+        {
+            "answers": {
+                "text": [],
+                "answer_start": []
+            }
+        }
+    """
+
+    dataset_name = "squad_v2"
+    configuration_name: str | None = None
+
+    def _get_query_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["question"])
+
+    def _get_response_from_example(self, example: dict[str, Any]) -> str:
+        answers = example.get("answers", {})
+        answer_texts = answers.get("text", [])
+
+        if answer_texts:
+            # Return the first answer (they are typically variations of the same answer)
+            return str(answer_texts[0])
+        else:
+            # For unanswerable questions, return a special token
+            return "[NO ANSWER]"
+
+    def _get_context_from_example(self, example: dict[str, Any]) -> str:
+        return str(example["context"])
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_extra_installed(cls, data: Any) -> Any:
+        """Validate that huggingface-evals dependencies are installed."""
+        check_huggingface_evals_installed(cls.__name__)
+        return data

--- a/tests/evals/benchmarks/huggingface/test_boolq.py
+++ b/tests/evals/benchmarks/huggingface/test_boolq.py
@@ -1,0 +1,58 @@
+"""Tests for BoolQ benchmark"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+import fed_rag.evals.benchmarks as benchmarks
+from fed_rag.data_structures.evals import BenchmarkExample
+
+
+@pytest.fixture
+def dummy_boolq() -> Dataset:
+    """Create a dummy BoolQ dataset for testing."""
+    return Dataset.from_dict(
+        {
+            "question": ["is confectionary sugar the same as powdered sugar"],
+            "answer": [True],
+            "passage": [
+                "Powdered sugar, also called confectioners' sugar, is a finely ground sugar ..."
+            ],
+        }
+    )
+
+
+@patch("datasets.load_dataset")
+def test_boolq_query_response_context_extractors(
+    mock_load_dataset: MagicMock, dummy_boolq: Dataset
+) -> None:
+    mock_load_dataset.return_value = dummy_boolq
+    boolq = benchmarks.HuggingFaceBoolQ()
+
+    assert isinstance(boolq[0], BenchmarkExample)
+    assert (
+        boolq[0].query == "is confectionary sugar the same as powdered sugar"
+    )
+    assert boolq[0].response == "true"
+    assert (
+        boolq[0].context
+        == "Powdered sugar, also called confectioners' sugar, is a finely ground sugar ..."
+    )
+
+
+@patch("datasets.load_dataset")
+def test_boolq_false_response(mock_load_dataset: MagicMock) -> None:
+    dataset = Dataset.from_dict(
+        {
+            "question": ["is elder scrolls online the same as skyrim"],
+            "answer": [False],
+            "passage": [
+                "As with other games in The Elder Scrolls series, the game is set on the continent of Tamriel."
+            ],
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    boolq = benchmarks.HuggingFaceBoolQ()
+
+    assert boolq[0].response == "false"

--- a/tests/evals/benchmarks/huggingface/test_hellaswag.py
+++ b/tests/evals/benchmarks/huggingface/test_hellaswag.py
@@ -1,0 +1,84 @@
+"""Tests for HellaSwag benchmark"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+import fed_rag.evals.benchmarks as benchmarks
+from fed_rag.data_structures.evals import BenchmarkExample
+
+
+@pytest.fixture
+def dummy_hellaswag() -> Dataset:
+    """Create a dummy HellaSwag dataset for testing."""
+    return Dataset.from_dict(
+        {
+            "ind": [4],
+            "activity_label": ["Removing ice from car"],
+            "ctx_a": [
+                "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles."
+            ],
+            "ctx_b": ["then"],
+            "ctx": [
+                "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles. then"
+            ],
+            "endings": [
+                [
+                    ", the man adds wax to the windshield and cuts it.",
+                    ", a person board a ski lift, while two men supporting the head of the person wearing winter clothes snow as the we girls sled.",
+                    ", the man puts on a christmas coat, knitted with netting.",
+                    ", the man continues removing the snow on his car.",
+                ]
+            ],
+            "source_id": ["activitynet~v_-1IBHYS3L-Y"],
+            "split": ["train"],
+            "split_type": ["indomain"],
+            "label": ["3"],
+        }
+    )
+
+
+@patch("datasets.load_dataset")
+def test_hellaswag_benchmark(
+    mock_load_dataset: MagicMock, dummy_hellaswag: Dataset
+) -> None:
+    mock_load_dataset.return_value = dummy_hellaswag
+    hellaswag = benchmarks.HuggingFaceHellaSwag()
+
+    assert isinstance(hellaswag[0], BenchmarkExample)
+    assert (
+        hellaswag[0].query
+        == "Then, the man writes over the snow covering the window of a car, and a woman wearing winter clothes smiles. then"
+    )
+    assert hellaswag[0].response == "3"
+    expected_context = (
+        "0: , the man adds wax to the windshield and cuts it.\n"
+        "1: , a person board a ski lift, while two men supporting the head of the person wearing winter clothes snow as the we girls sled.\n"
+        "2: , the man puts on a christmas coat, knitted with netting.\n"
+        "3: , the man continues removing the snow on his car."
+    )
+    assert hellaswag[0].context == expected_context
+
+
+@patch("datasets.load_dataset")
+def test_hellaswag_endings_structure(
+    mock_load_dataset: MagicMock, dummy_hellaswag: Dataset
+) -> None:
+    mock_load_dataset.return_value = dummy_hellaswag
+    hellaswag = benchmarks.HuggingFaceHellaSwag()
+    endings_field = hellaswag[0].context
+    endings_lines = endings_field.strip().split("\n")
+    assert len(endings_lines) == 4
+    assert all(isinstance(line, str) and line for line in endings_lines)
+
+
+@patch("datasets.load_dataset")
+def test_hellaswag_label_within_range(
+    mock_load_dataset: MagicMock, dummy_hellaswag: Dataset
+) -> None:
+    mock_load_dataset.return_value = dummy_hellaswag
+    hellaswag = benchmarks.HuggingFaceHellaSwag()
+    # Response should be between 0 and 3 for standard HellaSwag
+    response = int(hellaswag[0].response)
+    assert 0 <= response <= 3

--- a/tests/evals/benchmarks/huggingface/test_hotpotqa.py
+++ b/tests/evals/benchmarks/huggingface/test_hotpotqa.py
@@ -1,0 +1,177 @@
+"""Tests for HotpotQA benchmark"""
+
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+import fed_rag.evals.benchmarks as benchmarks
+from fed_rag.data_structures.evals import BenchmarkExample
+from fed_rag.exceptions import MissingExtraError
+
+
+@pytest.fixture
+def dummy_hotpotqa() -> Dataset:
+    """Create a dummy HotpotQA dataset for testing."""
+    return Dataset.from_dict(
+        {
+            "id": ["5a7a06935542990198eaf050"],
+            "question": [
+                "Which magazine was started first Arthur's Magazine or First for Women?"
+            ],
+            "answer": ["Arthur's Magazine"],
+            "type": ["comparison"],
+            "level": ["medium"],
+            "supporting_facts": [
+                {
+                    "title": ["Arthur's Magazine", "First for Women"],
+                    "sent_id": [0, 0],
+                }
+            ],
+            "context": [
+                {
+                    "title": [
+                        "Arthur's Magazine",
+                        "First for Women",
+                        "Other Magazine",
+                    ],
+                    "sentences": [
+                        [
+                            "Arthur's Magazine (1844–1846) was an American literary periodical.",
+                            "It was founded by Timothy Shay Arthur.",
+                        ],
+                        [
+                            "First for Women is a woman's magazine published by Bauer Media Group.",
+                            "The magazine was started in 1989.",
+                        ],
+                        ["This is another magazine.", "It has some content."],
+                    ],
+                }
+            ],
+        }
+    )
+
+
+@patch("datasets.load_dataset")
+def test_hotpotqa_benchmark(mock_load_dataset: MagicMock) -> None:
+    # arrange & act
+    hotpotqa = benchmarks.HuggingFaceHotpotQA()
+
+    # assert
+    mock_load_dataset.assert_called_once_with(
+        benchmarks.HuggingFaceHotpotQA.dataset_name,
+        name=hotpotqa.configuration_name,
+        split=hotpotqa.split,
+        streaming=hotpotqa.streaming,
+    )
+
+
+@patch("datasets.load_dataset")
+def test_hotpotqa_query_response_context_extractors(
+    mock_load_dataset: MagicMock, dummy_hotpotqa: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_hotpotqa
+    hotpotqa = benchmarks.HuggingFaceHotpotQA()
+
+    # assert
+    assert isinstance(hotpotqa[0], BenchmarkExample)
+    assert (
+        hotpotqa[0].query
+        == "Which magazine was started first Arthur's Magazine or First for Women?"
+    )
+    assert hotpotqa[0].response == "Arthur's Magazine"
+
+    expected_context = (
+        "Arthur's Magazine: Arthur's Magazine (1844–1846) was an American literary periodical. "
+        "It was founded by Timothy Shay Arthur. "
+        "First for Women: First for Women is a woman's magazine published by Bauer Media Group. "
+        "The magazine was started in 1989. "
+        "Other Magazine: This is another magazine. It has some content."
+    )
+    assert hotpotqa[0].context == expected_context
+
+
+@patch("datasets.load_dataset")
+def test_hotpotqa_no_context(mock_load_dataset: MagicMock) -> None:
+    """Test handling when context is missing or not a dict."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["1"],
+            "question": ["Test question?"],
+            "answer": ["Test answer"],
+            "type": ["comparison"],
+            "level": ["easy"],
+            "supporting_facts": [{"title": [], "sent_id": []}],
+            "context": ["This is not a dict"],  # Invalid context format
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    hotpotqa = benchmarks.HuggingFaceHotpotQA()
+    assert hotpotqa[0].context is None
+
+
+@patch("datasets.load_dataset")
+def test_hotpotqa_empty_context(mock_load_dataset: MagicMock) -> None:
+    """Test handling when context has empty title/sentences."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["1"],
+            "question": ["Test question?"],
+            "answer": ["Test answer"],
+            "type": ["comparison"],
+            "level": ["easy"],
+            "supporting_facts": [{"title": [], "sent_id": []}],
+            "context": [{"title": [], "sentences": []}],
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    hotpotqa = benchmarks.HuggingFaceHotpotQA()
+    assert hotpotqa[0].context is None
+
+
+@patch("datasets.load_dataset")
+def test_hotpotqa_missing_context_key(mock_load_dataset: MagicMock) -> None:
+    """Test handling when example has no context key."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["1"],
+            "question": ["Test question?"],
+            "answer": ["Test answer"],
+            "type": ["comparison"],
+            "level": ["easy"],
+            "supporting_facts": [{"title": [], "sent_id": []}]
+            # No context key
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    hotpotqa = benchmarks.HuggingFaceHotpotQA()
+    assert hotpotqa[0].context is None
+
+
+def test_huggingface_evals_extra_missing() -> None:
+    """Test that proper error is raised when huggingface-evals extra is missing."""
+    modules = {
+        "datasets": None,
+    }
+    module_to_import = "fed_rag.evals.benchmarks"
+    original_module = sys.modules.pop(module_to_import, None)
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`HuggingFaceHotpotQA` requires the `huggingface-evals` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface-evals]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            import fed_rag.evals.benchmarks as benchmarks
+
+            benchmarks.HuggingFaceHotpotQA()
+
+    # restore module so to not affect other tests
+    if original_module:
+        sys.modules[module_to_import] = original_module

--- a/tests/evals/benchmarks/huggingface/test_natural_questions.py
+++ b/tests/evals/benchmarks/huggingface/test_natural_questions.py
@@ -1,0 +1,495 @@
+"""Tests for Natural Questions benchmark"""
+
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+import fed_rag.evals.benchmarks as benchmarks
+from fed_rag.data_structures.evals import BenchmarkExample
+from fed_rag.exceptions import MissingExtraError
+
+
+@pytest.fixture
+def dummy_natural_questions_short_answer() -> Dataset:
+    """Create a dummy Natural Questions dataset with short answer."""
+    return Dataset.from_dict(
+        {
+            "id": ["5655493461695674962"],
+            "document": [
+                {
+                    "title": "Parma Heights, Ohio",
+                    "url": "https://en.wikipedia.org/wiki/Parma_Heights,_Ohio",
+                    "tokens": {
+                        "token": [
+                            "Parma",
+                            "Heights",
+                            "is",
+                            "a",
+                            "city",
+                            "in",
+                            "Cuyahoga",
+                            "County",
+                            ",",
+                            "Ohio",
+                            ".",
+                        ],
+                        "is_html": [
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                        ],
+                        "start_byte": [
+                            0,
+                            6,
+                            14,
+                            17,
+                            19,
+                            24,
+                            27,
+                            36,
+                            42,
+                            44,
+                            48,
+                        ],
+                        "end_byte": [
+                            5,
+                            13,
+                            16,
+                            18,
+                            23,
+                            26,
+                            35,
+                            42,
+                            43,
+                            48,
+                            49,
+                        ],
+                    },
+                }
+            ],
+            "question": [
+                {
+                    "text": "what county is parma heights ohio in",
+                    "tokens": [
+                        "what",
+                        "county",
+                        "is",
+                        "parma",
+                        "heights",
+                        "ohio",
+                        "in",
+                    ],
+                }
+            ],
+            "long_answer_candidates": [
+                {
+                    "start_byte": [0],
+                    "end_byte": [49],
+                    "start_token": [0],
+                    "end_token": [10],
+                    "top_level": [True],
+                }
+            ],
+            "annotations": [
+                {
+                    "id": ["4569326352834458124"],
+                    "long_answer": [
+                        {
+                            "start_byte": 0,
+                            "end_byte": 49,
+                            "start_token": 0,
+                            "end_token": 10,
+                            "candidate_index": 0,
+                        }
+                    ],
+                    "short_answers": [
+                        {
+                            "start_byte": [27],
+                            "end_byte": [42],
+                            "start_token": [6],
+                            "end_token": [7],
+                            "text": ["Cuyahoga County"],
+                        }
+                    ],
+                    "yes_no_answer": [-1],
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def dummy_natural_questions_yes_no() -> Dataset:
+    """Create a dummy Natural Questions dataset with yes/no answer."""
+    return Dataset.from_dict(
+        {
+            "id": ["1"],
+            "document": [
+                {
+                    "title": "Test",
+                    "tokens": {
+                        "token": ["Test", "document", "text", "."],
+                        "is_html": [False, False, False, False],
+                        "start_byte": [0, 5, 14, 18],
+                        "end_byte": [4, 13, 18, 19],
+                    },
+                }
+            ],
+            "question": [
+                {
+                    "text": "Is this a test?",
+                    "tokens": ["is", "this", "a", "test"],
+                }
+            ],
+            "annotations": [
+                {
+                    "id": ["123"],
+                    "long_answer": [
+                        {
+                            "candidate_index": -1,
+                            "start_byte": -1,
+                            "end_byte": -1,
+                            "start_token": -1,
+                            "end_token": -1,
+                        }
+                    ],
+                    "short_answers": [
+                        {
+                            "start_byte": [],
+                            "end_byte": [],
+                            "start_token": [],
+                            "end_token": [],
+                            "text": [],
+                        }
+                    ],
+                    "yes_no_answer": [1],  # YES
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def dummy_natural_questions_no_answer() -> Dataset:
+    """Create a dummy Natural Questions dataset with no answer."""
+    return Dataset.from_dict(
+        {
+            "id": ["2"],
+            "document": [
+                {
+                    "title": "Test",
+                    "tokens": {
+                        "token": ["Test", "document", "."],
+                        "is_html": [False, False, False],
+                        "start_byte": [0, 5, 13],
+                        "end_byte": [4, 13, 14],
+                    },
+                }
+            ],
+            "question": [
+                {
+                    "text": "What is unknown?",
+                    "tokens": ["what", "is", "unknown"],
+                }
+            ],
+            "annotations": [
+                {
+                    "id": ["456"],
+                    "long_answer": [
+                        {
+                            "candidate_index": -1,
+                            "start_byte": -1,
+                            "end_byte": -1,
+                            "start_token": -1,
+                            "end_token": -1,
+                        }
+                    ],
+                    "short_answers": [
+                        {
+                            "start_byte": [],
+                            "end_byte": [],
+                            "start_token": [],
+                            "end_token": [],
+                            "text": [],
+                        }
+                    ],
+                    "yes_no_answer": [-1],  # No yes/no answer
+                }
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def dummy_natural_questions_multiple_short_answers() -> Dataset:
+    """Create a dummy Natural Questions dataset with multiple short answers."""
+    return Dataset.from_dict(
+        {
+            "id": ["3"],
+            "document": [
+                {
+                    "title": "Google Founders",
+                    "tokens": {
+                        "token": [
+                            "Google",
+                            "was",
+                            "founded",
+                            "by",
+                            "Larry",
+                            "Page",
+                            "and",
+                            "Sergey",
+                            "Brin",
+                            ".",
+                        ],
+                        "is_html": [
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                            False,
+                        ],
+                        "start_byte": [0, 7, 11, 19, 22, 28, 33, 37, 44, 48],
+                        "end_byte": [6, 10, 18, 21, 27, 32, 36, 43, 48, 49],
+                    },
+                }
+            ],
+            "question": [
+                {
+                    "text": "who founded google",
+                    "tokens": ["who", "founded", "google"],
+                }
+            ],
+            "annotations": [
+                {
+                    "id": ["789"],
+                    "long_answer": [
+                        {
+                            "candidate_index": -1,
+                            "start_byte": -1,
+                            "end_byte": -1,
+                            "start_token": -1,
+                            "end_token": -1,
+                        }
+                    ],
+                    "short_answers": [
+                        {
+                            "start_byte": [22, 37],
+                            "end_byte": [32, 48],
+                            "start_token": [4, 7],
+                            "end_token": [5, 8],
+                            "text": ["Larry Page", "Sergey Brin"],
+                        }
+                    ],
+                    "yes_no_answer": [-1],
+                }
+            ],
+        }
+    )
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_benchmark(mock_load_dataset: MagicMock) -> None:
+    # arrange & act
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+
+    # assert
+    mock_load_dataset.assert_called_once_with(
+        benchmarks.HuggingFaceNaturalQuestions.dataset_name,
+        name=nq.configuration_name,
+        split=nq.split,  # Should be 'validation'
+        streaming=nq.streaming,
+    )
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_short_answer(
+    mock_load_dataset: MagicMock, dummy_natural_questions_short_answer: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_natural_questions_short_answer
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+
+    # assert
+    assert isinstance(nq[0], BenchmarkExample)
+    assert nq[0].query == "what county is parma heights ohio in"
+    assert nq[0].response == "Cuyahoga County"
+    assert (
+        nq[0].context == "Parma Heights is a city in Cuyahoga County , Ohio ."
+    )
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_multiple_short_answers(
+    mock_load_dataset: MagicMock,
+    dummy_natural_questions_multiple_short_answers: Dataset,
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = (
+        dummy_natural_questions_multiple_short_answers
+    )
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+
+    # assert
+    assert nq[0].response == "Larry Page and Sergey Brin"
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_yes_no_answer(
+    mock_load_dataset: MagicMock, dummy_natural_questions_yes_no: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_natural_questions_yes_no
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+
+    # assert
+    assert nq[0].response == "YES"
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_no_answer(
+    mock_load_dataset: MagicMock, dummy_natural_questions_no_answer: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_natural_questions_no_answer
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+
+    # assert
+    assert nq[0].response == "[NO ANSWER]"
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_long_answer_only(
+    mock_load_dataset: MagicMock,
+) -> None:
+    """Test handling when only long answer exists."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["4"],
+            "document": [
+                {
+                    "title": "Test",
+                    "tokens": {
+                        "token": ["Long", "document", "text", "."],
+                        "is_html": [False, False, False, False],
+                        "start_byte": [0, 5, 14, 18],
+                        "end_byte": [4, 13, 18, 19],
+                    },
+                }
+            ],
+            "question": [
+                {
+                    "text": "What is this about?",
+                    "tokens": ["what", "is", "this", "about"],
+                }
+            ],
+            "annotations": [
+                {
+                    "id": ["789"],
+                    "long_answer": [
+                        {
+                            "candidate_index": 0,
+                            "start_byte": 0,
+                            "end_byte": 19,
+                            "start_token": 0,
+                            "end_token": 3,
+                        }
+                    ],  # Valid long answer
+                    "short_answers": [
+                        {
+                            "start_byte": [],
+                            "end_byte": [],
+                            "start_token": [],
+                            "end_token": [],
+                            "text": [],
+                        }
+                    ],
+                    "yes_no_answer": [-1],
+                }
+            ],
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+    assert nq[0].response == "[LONG ANSWER EXISTS]"
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_no_annotations(
+    mock_load_dataset: MagicMock,
+) -> None:
+    """Test handling when annotations are missing."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["5"],
+            "document": [{"title": "Test"}],  # No tokens
+            "question": [{"text": "Test question?"}],
+            "annotations": [{}],  # Empty annotations
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+    assert nq[0].response == "[NO ANSWER]"
+    assert nq[0].context == "Test"  # Falls back to title
+
+
+@patch("datasets.load_dataset")
+def test_natural_questions_missing_fields(
+    mock_load_dataset: MagicMock,
+) -> None:
+    """Test handling when various fields are missing."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["6"],
+            "document": [{}],  # Empty document
+            "question": [{}],  # Empty question
+            "annotations": [{"yes_no_answer": [-1]}],
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    nq = benchmarks.HuggingFaceNaturalQuestions()
+    assert nq[0].query == ""
+    assert nq[0].response == "[NO ANSWER]"
+    assert nq[0].context is None
+
+
+def test_huggingface_evals_extra_missing() -> None:
+    """Test that proper error is raised when huggingface-evals extra is missing."""
+    modules = {
+        "datasets": None,
+    }
+    module_to_import = "fed_rag.evals.benchmarks"
+    original_module = sys.modules.pop(module_to_import, None)
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`HuggingFaceNaturalQuestions` requires the `huggingface-evals` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface-evals]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            import fed_rag.evals.benchmarks as benchmarks
+
+            benchmarks.HuggingFaceNaturalQuestions()
+
+    # restore module so to not affect other tests
+    if original_module:
+        sys.modules[module_to_import] = original_module

--- a/tests/evals/benchmarks/huggingface/test_squad_v2.py
+++ b/tests/evals/benchmarks/huggingface/test_squad_v2.py
@@ -1,0 +1,131 @@
+"""Tests for SQuAD 2.0 benchmark"""
+
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from datasets import Dataset
+
+import fed_rag.evals.benchmarks as benchmarks
+from fed_rag.data_structures.evals import BenchmarkExample
+from fed_rag.exceptions import MissingExtraError
+
+
+@pytest.fixture
+def dummy_squad_v2_answerable() -> Dataset:
+    """Create a dummy SQuAD 2.0 dataset with answerable question."""
+    return Dataset.from_dict(
+        {
+            "id": ["56ddde2d66d3e219004dad4d"],
+            "title": ["Symbiosis"],
+            "context": [
+                "Symbiotic relationships include those associations in which one organism lives on another (ectosymbiosis, such as..."
+            ],
+            "question": ["What is an example of ectosymbiosis?"],
+            "answers": [{"text": ["mistletoe"], "answer_start": [114]}],
+        }
+    )
+
+
+@pytest.fixture
+def dummy_squad_v2_unanswerable() -> Dataset:
+    """Create a dummy SQuAD 2.0 dataset with unanswerable question."""
+    return Dataset.from_dict(
+        {
+            "id": ["5ad3ed26604f3c001a3ff799"],
+            "title": ["Normans"],
+            "context": [
+                "The Normans were the people who gave their name to Normandy, a region in France."
+            ],
+            "question": ["What is the population of Normandy?"],
+            "answers": [{"text": [], "answer_start": []}],
+        }
+    )
+
+
+@patch("datasets.load_dataset")
+def test_squad_v2_benchmark(mock_load_dataset: MagicMock) -> None:
+    # arrange & act
+    squad = benchmarks.HuggingFaceSQuADv2()
+
+    # assert
+    mock_load_dataset.assert_called_once_with(
+        benchmarks.HuggingFaceSQuADv2.dataset_name,
+        name=squad.configuration_name,
+        split=squad.split,
+        streaming=squad.streaming,
+    )
+
+
+@patch("datasets.load_dataset")
+def test_squad_v2_answerable_question(
+    mock_load_dataset: MagicMock, dummy_squad_v2_answerable: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_squad_v2_answerable
+    squad = benchmarks.HuggingFaceSQuADv2()
+
+    # assert
+    assert isinstance(squad[0], BenchmarkExample)
+    assert squad[0].query == "What is an example of ectosymbiosis?"
+    assert squad[0].response == "mistletoe"
+    assert (
+        squad[0].context
+        == "Symbiotic relationships include those associations in which one organism lives on another (ectosymbiosis, such as..."
+    )
+
+
+@patch("datasets.load_dataset")
+def test_squad_v2_unanswerable_question(
+    mock_load_dataset: MagicMock, dummy_squad_v2_unanswerable: Dataset
+) -> None:
+    # arrange
+    mock_load_dataset.return_value = dummy_squad_v2_unanswerable
+    squad = benchmarks.HuggingFaceSQuADv2()
+
+    # assert
+    assert squad[0].response == "[NO ANSWER]"
+
+
+@patch("datasets.load_dataset")
+def test_squad_v2_missing_answers_field(mock_load_dataset: MagicMock) -> None:
+    """Test handling when answers field is missing."""
+    dataset = Dataset.from_dict(
+        {
+            "id": ["1"],
+            "title": ["Test"],
+            "context": ["Test context"],
+            "question": ["Test question?"]
+            # No answers field
+        }
+    )
+    mock_load_dataset.return_value = dataset
+    squad = benchmarks.HuggingFaceSQuADv2()
+    assert squad[0].response == "[NO ANSWER]"
+
+
+def test_huggingface_evals_extra_missing() -> None:
+    """Test that proper error is raised when huggingface-evals extra is missing."""
+    modules = {
+        "datasets": None,
+    }
+    module_to_import = "fed_rag.evals.benchmarks"
+    original_module = sys.modules.pop(module_to_import, None)
+
+    with patch.dict("sys.modules", modules):
+        msg = (
+            "`HuggingFaceSQuADv2` requires the `huggingface-evals` extra to be installed. "
+            "To fix please run `pip install fed-rag[huggingface-evals]`."
+        )
+        with pytest.raises(
+            MissingExtraError,
+            match=re.escape(msg),
+        ):
+            import fed_rag.evals.benchmarks as benchmarks
+
+            benchmarks.HuggingFaceSQuADv2()
+
+    # restore module so to not affect other tests
+    if original_module:
+        sys.modules[module_to_import] = original_module


### PR DESCRIPTION
## Summary

This PR adds support for five new HuggingFace benchmarks: HotpotQA, SQuAD v2, Natural Questions, BoolQ, and HellaSwag. These benchmarks expand FedRAG’s evaluation coverage for question answering and multi-choice reasoning tasks.

Description
This PR introduces standardized benchmarking modules for:

HotpotQA: Multi-hop question answering.
SQuAD v2: Extractive QA with unanswerable questions.
Natural Questions: Google QA dataset with long and short answers.
BoolQ: Boolean QA (yes/no) on Wikipedia passages.
HellaSwag: Commonsense reasoning and story completion.

Each benchmark includes:
-Dataset loader and context/response extraction logic
-Unit tests for context/response extraction and edge cases
-Docstrings and doc site references

No breaking changes to existing code.
No additional dependencies required beyond those already supported for HuggingFace datasets.
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
Any information reviewers should be aware of:

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved

## Checklist

Before submitting your PR, please check off the following:

- [x] My code follows the existing style and conventions
- [x] I’ve run linting (`make lint`)
- [x] I’ve added/updated relevant documentation
- [x] I’ve added/updated tests as needed
- [x I’ve verified integration with existing tools (HuggingFace, LlamaIndex, LangChain, etc. if applicable)
- [ ] I’ve added an entry to the CHANGELOG.md (if applicable)

## Related Issues or PRs

If this PR addresses or relates to existing issues or pull requests, link them here:

- Closes #364 
- Related to #
