### PR TITLE
[refactor] Add `BaseMCPKnowledgeSource` to be more dry with `MCPStdioKnowledgeSource` and `MCPStreamableHttpKnowledgeSoruce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Add `BaseMCPKnowledgeStore` (#400)
 - Add `MCPKnowledgeStore` and `MCPKnowledgeSource` (#393)
 - Add `AsyncRAGSystem` and `AsyncNoEncodeRAGSystem` (#392)
 - Validate installed version of bridge framework to confirm compatibility based on `BridgeMetadata` (#323)
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Refactor `MCPKnowledgeStore` and `MCPKnowledgeSource`to use new base and have `retrieve` method (#400)
 - Changed `load`, `count`, and `persist` methods in `AsyncNoEncodeRAGSystem` to sync (#393)
 - Modified private API for `_RAGSystem`, `_AsyncRAGSystem` and no-encode versions (#392)
 

--- a/src/fed_rag/knowledge_stores/no_encode/mcp/sources/base.py
+++ b/src/fed_rag/knowledge_stores/no_encode/mcp/sources/base.py
@@ -1,0 +1,70 @@
+"""Base MCP Knowledge Source Class"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from mcp.types import CallToolResult
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+from typing_extensions import Self
+
+from fed_rag.data_structures import KnowledgeNode
+
+from .utils import CallToolResultConverter, default_converter
+
+
+class BaseMCPKnowledgeSource(BaseModel, ABC):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_assignment=True
+    )
+    name: str
+    tool_name: str | None = None
+    query_param_name: str
+    tool_call_kwargs: dict[str, Any] = Field(default_factory=dict)
+    _converter_fn: CallToolResultConverter = PrivateAttr(
+        default=default_converter
+    )
+
+    @abstractmethod
+    async def retrieve(self, query: str) -> KnowledgeNode:
+        """Asynchronously retrieve knowledge from this source."""
+
+    # Common methods all sources share
+    def call_tool_result_to_knowledge_node(
+        self, result: CallToolResult
+    ) -> KnowledgeNode:
+        return self._converter_fn(result=result, metadata=self.model_dump())
+
+    def with_converter(self, converter_fn: CallToolResultConverter) -> Self:
+        """Setter for converter_fn.
+
+        Supports fluent pattern: `source = MCPStreamableHttpKnowledgeSource(...).with_converter()`
+        """
+        self._converter_fn = converter_fn
+        return self
+
+    def with_name(self, name: str) -> Self:
+        """Setter for name.
+
+        For convenience and users who prefer the fluent style.
+        """
+
+        self.name = name
+        return self
+
+    def with_query_param_name(self, v: str) -> Self:
+        """Setter for query param name.
+
+        For convenience and users who prefer the fluent style.
+        """
+
+        self.query_param_name = v
+        return self
+
+    def with_tool_call_kwargs(self, v: dict[str, Any]) -> Self:
+        """Setter for tool call kwargs.
+
+        For convenience and users who prefer the fluent style.
+        """
+
+        self.tool_call_kwargs = v
+        return self

--- a/src/fed_rag/knowledge_stores/no_encode/mcp/sources/base.py
+++ b/src/fed_rag/knowledge_stores/no_encode/mcp/sources/base.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 
 from fed_rag.data_structures import KnowledgeNode
 
-from .utils import CallToolResultConverter, default_converter
+from .utils import CallToolResultConverter
 
 
 class BaseMCPKnowledgeSource(BaseModel, ABC):
@@ -20,9 +20,7 @@ class BaseMCPKnowledgeSource(BaseModel, ABC):
     tool_name: str | None = None
     query_param_name: str
     tool_call_kwargs: dict[str, Any] = Field(default_factory=dict)
-    _converter_fn: CallToolResultConverter = PrivateAttr(
-        default=default_converter
-    )
+    _converter_fn: CallToolResultConverter = PrivateAttr()
 
     @abstractmethod
     async def retrieve(self, query: str) -> KnowledgeNode:

--- a/src/fed_rag/knowledge_stores/no_encode/mcp/sources/stdio.py
+++ b/src/fed_rag/knowledge_stores/no_encode/mcp/sources/stdio.py
@@ -5,16 +5,15 @@ from typing import Any
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.types import CallToolResult
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from typing_extensions import Self
 
 from fed_rag.data_structures import KnowledgeNode
 
+from .base import BaseMCPKnowledgeSource
 from .utils import CallToolResultConverter, default_converter
 
 
-class MCPStdioKnowledgeSource(BaseModel):
+class MCPStdioKnowledgeSource(BaseMCPKnowledgeSource):
     """The MCPStdioKnowledgeSource class.
 
     Users can easily connect MCP tools as their source of knowledge in RAG systems
@@ -22,14 +21,6 @@ class MCPStdioKnowledgeSource(BaseModel):
     """
 
     server_params: StdioServerParameters
-    name: str
-    tool_name: str | None = None
-    query_param_name: str
-    tool_call_kwargs: dict[str, Any] = Field(default_factory=dict)
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True, validate_assignment=True
-    )
-    _converter_fn: CallToolResultConverter = PrivateAttr()
 
     def __init__(
         self,
@@ -51,41 +42,6 @@ class MCPStdioKnowledgeSource(BaseModel):
         )
         self._converter_fn = converter_fn or default_converter
 
-    def with_converter(self, converter_fn: CallToolResultConverter) -> Self:
-        """Setter for converter_fn.
-
-        Supports fluent pattern: `source = MCPStdioKnowledgeSource(...).with_converter()`
-        """
-        self._converter_fn = converter_fn
-        return self
-
-    def with_name(self, name: str) -> Self:
-        """Setter for name.
-
-        For convenience and users who prefer the fluent style.
-        """
-
-        self.name = name
-        return self
-
-    def with_query_param_name(self, v: str) -> Self:
-        """Setter for query param name.
-
-        For convenience and users who prefer the fluent style.
-        """
-
-        self.query_param_name = v
-        return self
-
-    def with_tool_call_kwargs(self, v: dict[str, Any]) -> Self:
-        """Setter for tool call kwargs.
-
-        For convenience and users who prefer the fluent style.
-        """
-
-        self.tool_call_kwargs = v
-        return self
-
     def with_server_params(self, server_params: StdioServerParameters) -> Self:
         """Setter for server params.
 
@@ -94,13 +50,6 @@ class MCPStdioKnowledgeSource(BaseModel):
 
         self.server_params = server_params
         return self
-
-    def call_tool_result_to_knowledge_node(
-        self,
-        result: CallToolResult,
-    ) -> KnowledgeNode:
-        """Convert a call tool result to a knowledge node."""
-        return self._converter_fn(result=result, metadata=self.model_dump())
 
     async def retrieve(self, query: str) -> KnowledgeNode:
         async with stdio_client(self.server_params) as (read, write):

--- a/src/fed_rag/knowledge_stores/no_encode/mcp/sources/utils.py
+++ b/src/fed_rag/knowledge_stores/no_encode/mcp/sources/utils.py
@@ -21,7 +21,7 @@ def default_converter(
             "Cannot convert a `CallToolResult` with `isError` set to `True`."
         )
 
-    text_content = "\n".join(
+    text_content = "<<<CONTENT_SEPARATOR>>>".join(
         c.text for c in result.content if c.type == "text"
     )
     metadata = metadata or {}

--- a/tests/knowledge_stores/no_encode/mcp/test_mcp_store.py
+++ b/tests/knowledge_stores/no_encode/mcp/test_mcp_store.py
@@ -66,8 +66,12 @@ def test_mcp_knowledge_store_init(
 
 
 @pytest.mark.asyncio
-@patch("fed_rag.knowledge_stores.no_encode.mcp.store.ClientSession")
-@patch("fed_rag.knowledge_stores.no_encode.mcp.store.streamablehttp_client")
+@patch(
+    "fed_rag.knowledge_stores.no_encode.mcp.sources.streamable_http.ClientSession"
+)
+@patch(
+    "fed_rag.knowledge_stores.no_encode.mcp.sources.streamable_http.streamablehttp_client"
+)
 async def test_mcp_knowledge_store_retrieve_streamable_http(
     mock_streamable_client: AsyncMock,
     mock_session_class: AsyncMock,
@@ -113,8 +117,8 @@ async def test_mcp_knowledge_store_retrieve_streamable_http(
 
 
 @pytest.mark.asyncio
-@patch("fed_rag.knowledge_stores.no_encode.mcp.store.ClientSession")
-@patch("fed_rag.knowledge_stores.no_encode.mcp.store.stdio_client")
+@patch("fed_rag.knowledge_stores.no_encode.mcp.sources.stdio.ClientSession")
+@patch("fed_rag.knowledge_stores.no_encode.mcp.sources.stdio.stdio_client")
 async def test_mcp_knowledge_store_retrieve_stdio(
     mock_stdio_client: AsyncMock,
     mock_session_class: AsyncMock,
@@ -164,18 +168,6 @@ async def test_add_unsupported_source_type_raises_error() -> None:
         match="Cannot add source of type: <class 'int'>",
     ):
         _ = MCPKnowledgeStore().add_source(1)
-
-
-@pytest.mark.asyncio
-async def test_retrieve_raises_error_with_unsupported_source_type() -> None:
-    store = MCPKnowledgeStore()
-    store.sources["oops"] = 1
-
-    with pytest.raises(
-        MCPKnowledgeStoreError,
-        match="Unsupported source type: <class 'int'>",
-    ):
-        _ = await store.retrieve("mock query", top_k=2)
 
 
 def test_add_source_raises_error_with_existing_name(


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [x] Other (please describe): refactor

## Description

### Added

- `BaseMCPKnowledgeSource` and outsourced a lot of common methods and attributes here
-  Added the `retrieve` method to each source

### Changed

- `MCPKnowledgeStore` now only calls the soruces' respective `retrieve` method.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [ ] Code coverage maintained or improved

