### PR TITLE
Feat/gemma3n generator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples-vector-compute"]
+	path = examples-vector-compute
+	url = git@github.com:VectorInstitute/fed-rag-examples-vector-compute.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples-vector-compute"]
-	path = examples-vector-compute
-	url = https://github.com/VectorInstitute/fed-rag-examples-vector-compute.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples-vector-compute"]
 	path = examples-vector-compute
-	url = git@github.com:VectorInstitute/fed-rag-examples-vector-compute.git
+	url = https://github.com/VectorInstitute/fed-rag-examples-vector-compute.git

--- a/docs/api_reference/generators/huggingface.md
+++ b/docs/api_reference/generators/huggingface.md
@@ -9,3 +9,8 @@
     options:
       members:
         - HFPretrainedModelGenerator
+
+::: src.fed_rag.generators.huggingface.gemma3n_generator
+options:
+  members:
+    - Gemma3nGenerator

--- a/docs/notebooks/rag_benchmarking_hf_mmlu.ipynb
+++ b/docs/notebooks/rag_benchmarking_hf_mmlu.ipynb
@@ -9,7 +9,7 @@
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>\n",
     "\n",
-    "_(NOTE: if running on Colab, you will need to supply a WandB API Key in addition to your HFToken. Also, you'll need to change the runtime to a T4.)_"
+    "_(NOTE: if running on Colab, you will need to supply a HFToken. Also, you'll need to change the runtime to a L4.)_"
    ]
   },
   {
@@ -17,15 +17,23 @@
    "id": "930123f4-a6d3-4a0d-953f-2bd84cb415c4",
    "metadata": {},
    "source": [
-    "# Benchmarking RAG Systems (MMLU)\n",
+    "# Benchmarking RAG Systems with FedRAG and Gemma 3n on MMLU\n",
     "\n",
-    "In this note book, we demonstrate how one benchmark a RAG system with the `fed-rag` library. Doing so, involves the following steps:\n",
+    "In this note book, we demonstrate how one benchmark a RAG system with the `fed-rag` library with Google’s Gemma 3n model on the MMLU dataset.\n",
     "\n",
-    "1. Build your `RAGSystem` to be benchmarked\n",
-    "2. Create a `Benchmarker` object\n",
-    "3. Choose your `Benchmark` and run it with the `BenchMarker`\n",
+    "We will walk through the following steps:\n",
     "\n",
-    "In this notebook, we'll make use of the `huggingface-evals` extra which will allow us to utilize the benchmarks defined in the `fed_rag.evals.benchmarks.huggingface` module."
+    "1. Build your `RAGSystem` to be benchmarked (with a retriever, knowledge store, and LLM generator)\n",
+    "2. Create a `Benchmarker` object to manage evaluation runs\n",
+    "3. Choose your `Benchmark (MMLU)` and run it using the `Benchmarker`\n",
+    "\n",
+    "In this notebook, we'll make use of the `huggingface-evals` extra which will allow us to utilize the benchmarks defined in the `fed_rag.evals.benchmarks.huggingface` module.\n",
+    "\n",
+    "Requirements:\n",
+    "\n",
+    "- A Hugging Face account with access to Gemma 3n, and your Hugging Face API token (see cell below for setup).\n",
+    "\n",
+    "- (Colab) Set your runtime to a GPU instance with sufficient RAM (L4 or better recommended)."
    ]
   },
   {
@@ -38,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "254d8fc1-90a3-4f8d-a68a-cd6a43572913",
    "metadata": {},
    "outputs": [
@@ -51,9 +59,32 @@
     }
    ],
    "source": [
-    "# If running in a Google Colab, the first attempt at installing fed-rag may fail,\n",
-    "# though for reasons unknown to me yet, if you try a second time, it magically works...\n",
-    "!pip install fed-rag[huggingface,huggingface-evals] -q"
+    "# Install the latest fed-rag, transformers, and timm.\n",
+    "!pip install fed-rag[huggingface,huggingface-evals]\n",
+    "\n",
+    "# Update libraries needed for Gemma3n.\n",
+    "!pip install --upgrade transformers timm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5dc460b",
+   "metadata": {},
+   "source": [
+    "### Authenticate to HuggingFace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04bc45ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from huggingface_hub import notebook_login\n",
+    "\n",
+    "# This will prompt you for your Hugging Face token\n",
+    "notebook_login()"
    ]
   },
   {
@@ -177,63 +208,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "6d885b4e-ba5d-45c0-9ccf-cd1354d7d709",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fed_rag.generators.huggingface import HFPretrainedModelGenerator\n",
-    "import torch\n",
-    "from transformers.generation.utils import GenerationConfig\n",
-    "\n",
-    "generation_cfg = GenerationConfig(\n",
-    "    do_sample=True,\n",
-    "    eos_token_id=151643,\n",
-    "    bos_token_id=151643,\n",
-    "    max_new_tokens=2048,\n",
-    "    top_p=0.9,\n",
-    "    temperature=0.6,\n",
-    "    cache_implementation=\"offloaded\",\n",
-    "    stop_strings=\"</response>\",\n",
-    ")\n",
-    "generator = HFPretrainedModelGenerator(\n",
-    "    model_name=\"Qwen/Qwen2.5-0.5B\",\n",
-    "    load_model_at_init=False,\n",
-    "    load_model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": torch.float16},\n",
-    "    generation_config=generation_cfg,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "cae62642-0e6c-4d04-9ac1-315d169e86f4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# load nodes\n",
-    "knowledge_store.load_nodes(nodes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "8fac17ba-a86b-4a47-9aae-32cefc7cdc6b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "knowledge_store.count"
+    "knowledge_store.load_nodes(nodes)\n",
+    "print(\"Knowledge nodes loaded:\", knowledge_store.count)"
    ]
   },
   {
@@ -246,31 +228,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "b665ea34",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fed_rag.generators.huggingface import HFPretrainedModelGenerator\n",
-    "import torch\n",
-    "from transformers.generation.utils import GenerationConfig\n",
+    "from fed_rag.generators.huggingface.gemma3n_generator import Gemma3nGenerator\n",
     "\n",
-    "generation_cfg = GenerationConfig(\n",
-    "    do_sample=True,\n",
-    "    eos_token_id=151643,\n",
-    "    bos_token_id=151643,\n",
-    "    max_new_tokens=2048,\n",
-    "    top_p=0.9,\n",
-    "    temperature=0.6,\n",
-    "    cache_implementation=\"offloaded\",\n",
-    "    stop_strings=\"</response>\",\n",
-    ")\n",
-    "generator = HFPretrainedModelGenerator(\n",
-    "    model_name=\"Qwen/Qwen2.5-0.5B\",\n",
-    "    load_model_at_init=False,\n",
-    "    load_model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": torch.float16},\n",
-    "    generation_config=generation_cfg,\n",
+    "generator = Gemma3nGenerator(\n",
+    "    model_name=\"google/gemma-3n-e2b-it\",\n",
+    "    device=\"cuda\",  # or \"cpu\" for CPU inference\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45b63594",
+   "metadata": {},
+   "source": [
+    "If running on CPU and see OOM errors, switch device accordingly."
    ]
   },
   {
@@ -301,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "146a5c38-476f-402e-b1cc-aaed0c5e7de4",
    "metadata": {},
    "outputs": [
@@ -317,25 +293,16 @@
    ],
    "source": [
     "# test a query\n",
-    "response = rag_system.query(\"Who is James Cook?\")"
+    "response = rag_system.query(\"Who is James Cook?\")\n",
+    "print(response)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "0b4d7dd4-383c-427e-a4f2-5e65b453a3e4",
+   "cell_type": "markdown",
+   "id": "a607e79a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assistant: James Cook is well known for his voyages of exploration for the British Navy in which he mapped out a significant amount of the world's uncharted waters. Cook's explorations took him around the world twice and led to countless descriptions of previously unknown plants and animals. Cook's explorations influenced many others and led to a number of scientists examining marine life more closely. Among those influenced was Charles Darwin who went on to make many contributions of his own.\n"
-     ]
-    }
-   ],
    "source": [
-    "print(response)"
+    "## Perform Benchmarking"
    ]
   },
   {
@@ -343,12 +310,12 @@
    "id": "cf96af83-b555-4e83-a8f7-93c6501214f8",
    "metadata": {},
    "source": [
-    "## Create `Benchmarker`"
+    "### Create `Benchmarker`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "2ea97c9a-48e2-4db9-ac68-6685c133185e",
    "metadata": {},
    "outputs": [],
@@ -358,8 +325,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "d98fe073-db81-4291-8a9f-805ba2edf765",
+   "execution_count": null,
+   "id": "500094bf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +338,7 @@
    "id": "46236860-5bfd-4113-b9dd-22f13f0ff87c",
    "metadata": {},
    "source": [
-    "## Get the desired Benchmark (MMLU)"
+    "### Get the desired Benchmark (MMLU)"
    ]
   },
   {
@@ -384,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "a0f382e2-e879-4123-99c9-c7e8ffc24c12",
    "metadata": {},
    "outputs": [],
@@ -440,7 +407,7 @@
    "id": "34cfc49d-5a81-4175-bdf3-c6168f2368a4",
    "metadata": {},
    "source": [
-    "## Define our Evaluation Metric"
+    "### Define our Evaluation Metric"
    ]
   },
   {
@@ -566,10 +533,55 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6a80c253",
+   "metadata": {},
+   "source": [
+    "### Multiple-Choice Prompt: Default and Customization\n",
+    "\n",
+    "fed-rag sets a default prompt for MMLU so that LLMs like Gemma 3n answer with only a single letter (A, B, C, or D). This keeps the evaluation automatic and reliable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffbc1d50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mmlu.prompt_template = \"\"\"\n",
+    "{question}\n",
+    "A. {A}\n",
+    "B. {B}\n",
+    "C. {C}\n",
+    "D. {D}\n",
+    "\n",
+    "You MUST answer ONLY with a single letter (A, B, C, or D). Do NOT provide any explanation, reasoning, or extra text. Answers with any additional text are considered incorrect.\n",
+    "\n",
+    "Example of a correct answer:\n",
+    "B\n",
+    "\n",
+    "Example of an incorrect answer:\n",
+    "B. Because...\n",
+    "\n",
+    "Answer:\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ecc0039",
+   "metadata": {},
+   "source": [
+    "Customizing the prompt:\n",
+    "If you want to experiment with different prompting strategies, just assign your own prompt to `mmlu.prompt_template` above to override the default prompt."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "75b43ff3-a92b-4226-88d2-f97ec9ea27b6",
    "metadata": {},
    "source": [
-    "## Run the benchmark"
+    "### Run the benchmark!"
    ]
   },
   {
@@ -630,61 +642,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
-   "id": "5dfee6c3-74ff-4331-8a87-3955735070e0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fed_rag.evals.utils import load_evaluations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "9f655b1c-e659-40ef-bc59-5a92dcb3fbf2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluations = load_evaluations(result.evaluations_file)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "b94b3792-12ef-4f12-938f-e76170a59830",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "evaluations[1].score"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "id": "a2de7291-9e5b-4391-9dbb-4d8fc315b25f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Assistant: The degree of the field extension Q(sqrt(2), sqrt(3), sqrt(18)) over Q is 0.\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(evaluations[0].rag_response)"
+    "from fed_rag.evals.utils import load_evaluations\n",
+    "\n",
+    "evaluations = load_evaluations(result.evaluations_file)\n",
+    "\n",
+    "print(\"Score for first example:\", evaluations[0].score)\n",
+    "print(\"Model output for second example:\", evaluations[1].rag_response.response)\n",
+    "print(\"Prompt template used:\\n\", mmlu.prompt_template)"
    ]
   }
  ],

--- a/docs/notebooks/rag_benchmarking_hf_mmlu.ipynb
+++ b/docs/notebooks/rag_benchmarking_hf_mmlu.ipynb
@@ -74,10 +74,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "1c807325-2ac6-417a-a0f7-7b2ae3762b60",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'fed_rag'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mModuleNotFoundError\u001b[39m                       Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mfed_rag\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mknowledge_stores\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01min_memory\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m InMemoryKnowledgeStore\n\u001b[32m      2\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mfed_rag\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mretrievers\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mhuggingface\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mhf_sentence_transformer\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m (\n\u001b[32m      3\u001b[39m     HFSentenceTransformerRetriever,\n\u001b[32m      4\u001b[39m )\n\u001b[32m      6\u001b[39m knowledge_store = InMemoryKnowledgeStore()\n",
+      "\u001b[31mModuleNotFoundError\u001b[39m: No module named 'fed_rag'"
+     ]
+    }
+   ],
    "source": [
     "from fed_rag.knowledge_stores.in_memory import InMemoryKnowledgeStore\n",
     "from fed_rag.retrievers.huggingface.hf_sentence_transformer import (\n",
@@ -678,7 +690,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -692,7 +704,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,

--- a/src/fed_rag/evals/benchmarker.py
+++ b/src/fed_rag/evals/benchmarker.py
@@ -1,10 +1,12 @@
 """Base Benchmark and Benchmarker"""
 
 import contextlib
+import gc
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generator
 
+import torch
 from pydantic import BaseModel
 from typing_extensions import assert_never
 
@@ -176,6 +178,9 @@ class Benchmarker(BaseModel):
                     )
 
                     num_seen += 1
+
+                    torch.cuda.empty_cache()
+                    gc.collect()
         finally:
             if f:
                 f.close()

--- a/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
@@ -9,15 +9,23 @@ from fed_rag.base.evals.benchmark import BaseBenchmark
 from .mixin import HuggingFaceBenchmarkMixin
 from .utils import check_huggingface_evals_installed
 
-DEFAULT_MMLU_PROMPT = (
-    "{question}\n"
-    "A. {A}\n"
-    "B. {B}\n"
-    "C. {C}\n"
-    "D. {D}\n\n"
-    "Please select the correct answer from A, B, C, or D and respond with only the corresponding letter.\n"
-    "Answer:"
-)
+DEFAULT_MMLU_PROMPT = """
+    {question}
+    A. {A}
+    B. {B}
+    C. {C}
+    D. {D}
+
+    You MUST answer ONLY with a single letter (A, B, C, or D). Do NOT provide any explanation, reasoning, or extra text. Answers with any additional text are considered incorrect.
+
+    Example of a correct answer:
+    B
+
+    Example of an incorrect answer:
+    B. Because...
+
+    Answer:
+"""
 
 
 class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):

--- a/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
@@ -2,7 +2,7 @@
 
 from typing import Any, ClassVar
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from fed_rag.base.evals.benchmark import BaseBenchmark
 
@@ -39,7 +39,7 @@ class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
     dataset_name = "cais/mmlu"
     configuration_name: str = "all"
     response_key: ClassVar[dict[int, str]] = {0: "A", 1: "B", 2: "C", 3: "D"}
-    prompt_template: str = DEFAULT_MMLU_PROMPT
+    prompt_template: str = Field(default=DEFAULT_MMLU_PROMPT)
 
     def _get_query_from_example(self, example: dict[str, Any]) -> str:
         choices = example["choices"]

--- a/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
@@ -39,7 +39,7 @@ class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
     dataset_name = "cais/mmlu"
     configuration_name: str = "all"
     response_key: ClassVar[dict[int, str]] = {0: "A", 1: "B", 2: "C", 3: "D"}
-    prompt_template: str = Field(default=DEFAULT_MMLU_PROMPT)
+    prompt_template: str = Field(DEFAULT_MMLU_PROMPT)
 
     def _get_query_from_example(self, example: dict[str, Any]) -> str:
         choices = example["choices"]

--- a/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
+++ b/src/fed_rag/evals/benchmarks/huggingface/mmlu.py
@@ -9,6 +9,16 @@ from fed_rag.base.evals.benchmark import BaseBenchmark
 from .mixin import HuggingFaceBenchmarkMixin
 from .utils import check_huggingface_evals_installed
 
+DEFAULT_MMLU_PROMPT = (
+    "{question}\n"
+    "A. {A}\n"
+    "B. {B}\n"
+    "C. {C}\n"
+    "D. {D}\n\n"
+    "Please select the correct answer from A, B, C, or D and respond with only the corresponding letter.\n"
+    "Answer:"
+)
+
 
 class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
     """HuggingFace MMLU Benchmark.
@@ -29,11 +39,17 @@ class HuggingFaceMMLU(HuggingFaceBenchmarkMixin, BaseBenchmark):
     dataset_name = "cais/mmlu"
     configuration_name: str = "all"
     response_key: ClassVar[dict[int, str]] = {0: "A", 1: "B", 2: "C", 3: "D"}
+    prompt_template: str = DEFAULT_MMLU_PROMPT
 
     def _get_query_from_example(self, example: dict[str, Any]) -> str:
         choices = example["choices"]
-        formatted_choices = f"A: {choices[0]}\nB: {choices[1]}\nC: {choices[2]}\nD: {choices[3]}"
-        return f"{example['question']}\n\n{formatted_choices}"
+        return self.prompt_template.format(
+            question=example["question"],
+            A=choices[0],
+            B=choices[1],
+            C=choices[2],
+            D=choices[3],
+        )
 
     def _get_response_from_example(self, example: dict[str, Any]) -> str:
         return self.response_key[example["answer"]]

--- a/src/fed_rag/generators/huggingface/__init__.py
+++ b/src/fed_rag/generators/huggingface/__init__.py
@@ -1,4 +1,9 @@
+from .gemma3n_generator import Gemma3nGenerator
 from .hf_peft_model import HFPeftModelGenerator
 from .hf_pretrained_model import HFPretrainedModelGenerator
 
-__all__ = ["HFPeftModelGenerator", "HFPretrainedModelGenerator"]
+__all__ = [
+    "HFPeftModelGenerator",
+    "HFPretrainedModelGenerator",
+    "Gemma3nGenerator",
+]

--- a/src/fed_rag/generators/huggingface/gemma3n_generator.py
+++ b/src/fed_rag/generators/huggingface/gemma3n_generator.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:  # pragma: no cover
     pass
 
 import torch
+from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from fed_rag.base.generator import BaseGenerator
 
@@ -28,8 +29,6 @@ class Gemma3nGenerator(BaseGenerator):
         device_map: str = "auto",
         torch_dtype: str = "auto",
     ):
-        from transformers import AutoModelForImageTextToText, AutoProcessor
-
         self._processor = AutoProcessor.from_pretrained(model_name)
         self._model = AutoModelForImageTextToText.from_pretrained(
             model_name

--- a/src/fed_rag/generators/huggingface/gemma3n_generator.py
+++ b/src/fed_rag/generators/huggingface/gemma3n_generator.py
@@ -1,0 +1,107 @@
+"""Gemma 3n Generator"""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+import torch
+
+from fed_rag.base.generator import BaseGenerator
+
+
+class Gemma3nGenerator(BaseGenerator):
+    """
+    Generator for Gemma 3n models via HuggingFace Transformers.
+
+    Uses AutoProcessor and AutoModelForImageTextToText for inference.
+    """
+
+    _model: Any
+    _processor: Any
+    _device: str
+
+    def __init__(
+        self,
+        model_name: str = "google/gemma-3n-e2b-it",
+        device: str = "cuda",
+        device_map: str = "auto",
+        torch_dtype: str = "auto",
+    ):
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
+        self._processor = AutoProcessor.from_pretrained(model_name)
+        self._model = AutoModelForImageTextToText.from_pretrained(
+            model_name
+        ).to(device)
+        self._device = device
+
+    def generate(self, query: str, context: str = "", **kwargs: Any) -> str:
+        """
+        Generate a response using Gemma 3n. Returns decoded string output.
+
+        Args:
+            query (str): The prompt or question for the model.
+            context (str): Optional additional context.
+            **kwargs: Additional kwargs are ignored.
+
+        Returns:
+            str: The generated response from the model.
+        """
+        text = f"{context}\n\n{query}" if context else query
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": text}],
+            }
+        ]
+        inputs = self._processor.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        input_len = inputs["input_ids"].shape[-1]
+        inputs = {
+            k: (
+                v.to(self._model.device, dtype=torch.long)
+                if k == "input_ids"
+                else v.to(self._model.device)
+            )
+            for k, v in inputs.items()
+        }
+        with torch.inference_mode():
+            generation = self._model.generate(
+                **inputs, max_new_tokens=256, disable_compile=False
+            )
+            generation = generation[:, input_len:]
+        decoded = self._processor.batch_decode(
+            generation, skip_special_tokens=True
+        )
+        if not decoded or not isinstance(decoded[0], str):
+            raise RuntimeError(
+                "batch_decode did not return a non-empty list of strings"
+            )
+        return decoded[0]
+
+    @property
+    def model(self) -> Any:
+        """Return the underlying HuggingFace model."""
+        return self._model
+
+    @property
+    def tokenizer(self) -> Any:
+        """Return the associated processor (used as tokenizer)."""
+        return self._processor
+
+    @property
+    def prompt_template(self) -> str:
+        """Return an empty prompt template (not used for Gemma3n)."""
+        return ""
+
+    def complete(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("Not implemented for Gemma3nGenerator.")
+
+    def compute_target_sequence_proba(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("Not implemented for Gemma3nGenerator.")

--- a/tests/generators/test_gemma3n_generator.py
+++ b/tests/generators/test_gemma3n_generator.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5,6 +6,13 @@ import torch
 
 from fed_rag.base.generator import BaseGenerator
 from fed_rag.generators.huggingface.gemma3n_generator import Gemma3nGenerator
+
+
+def _has_hf_token():
+    return bool(
+        os.environ.get("HF_TOKEN")
+        or os.environ.get("HUGGINGFACEHUB_API_TOKEN")
+    )
 
 
 def test_gemma3n_generator_inherits_base() -> None:
@@ -72,6 +80,10 @@ def test_gemma3n_generator_generate(
     assert result == "A"
 
 
+@pytest.mark.skipif(
+    not _has_hf_token(),
+    reason="Hugging Face token not set. Skipping test that requires a remote call.",
+)
 def test_gemma3n_generator_prompt_template_property() -> None:
     generator = Gemma3nGenerator(
         model_name="google/gemma-3n-e2b-it", device="cpu"
@@ -80,6 +92,10 @@ def test_gemma3n_generator_prompt_template_property() -> None:
     assert generator.prompt_template == ""
 
 
+@pytest.mark.skipif(
+    not _has_hf_token(),
+    reason="Hugging Face token not set. Skipping test that requires a remote call.",
+)
 def test_gemma3n_generator_not_implemented_methods() -> None:
     generator = Gemma3nGenerator(
         model_name="google/gemma-3n-e2b-it", device="cpu"


### PR DESCRIPTION
## Summary

This PR introduces support for the newly released Google Gemma 3n model as a generator in FedRAG, 
adds a robust prompt mechanism for the MMLU benchmark, 
and improves memory management during benchmarking to prevent GPU OOM errors.

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Code quality / linting
- [ ] Other (please describe):

## Description
- New Generator:
Adds `Gemma3nGenerator` in `fed_rag/generators/huggingface/gemma3n_generator.py` to enable inference with the Gemma 3n model (which uses AutoModelForImageTextToText and AutoProcessor).
This is necessary because the default `HFPretrainedModelGenerator` does not support models with image and text input pipelines like Gemma 3n.

- Benchmark Prompt Customization:
Updates `mmlu.py` to include a default MMLU prompt (`DEFAULT_MMLU_PROMPT`), exposed via the `prompt_template` attribute.
This default prompt enforces single-letter output (A/B/C/D) for benchmarking, but users can override it as needed.

- OOM Error Mitigation:
Updates `benchmarker.py` to clear GPU memory (`torch.cuda.empty_cache(), gc.collect()`) after each inference step, reducing the chance of CUDA out-of-memory errors in batch or streaming evaluation scenarios.

- Testing:
Adds comprehensive unit tests for `Gemma3nGenerator`.
Tests are structured to skip inference that requires a Hugging Face token when unavailable, but full functionality has been confirmed in Google Colab using a valid token.

Documentation:
Updates the API reference to include `Gemma3nGenerator` and clarifies prompt customization for MMLU.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
- [x] Manual testing performed on Colab notebook with end-to-end benchmarking (Gemma 3n + MMLU + RAG)

## Checklist

Before submitting your PR, please check off the following:

- [x] My code follows the existing style and conventions
- [x] I’ve run linting (`make lint`)
- [x] I’ve added/updated relevant documentation
- [x] I’ve added/updated tests as needed
- [x] I’ve verified integration with existing tools (HuggingFace)
- [ ] I’ve added an entry to the CHANGELOG.md (if applicable)

## Related Issues or PRs

If this PR addresses or relates to existing issues or pull requests, link them here:

- Closes #
- Related to #
