### PR TITLE
[Feature] Expand `BaseGenerator` methods for multi-modal and add new `fed_rag.data_structures`

### DIFF
--- a/src/fed_rag/base/generator.py
+++ b/src/fed_rag/base/generator.py
@@ -6,6 +6,7 @@ import torch
 from pydantic import BaseModel, ConfigDict
 
 from fed_rag.base.tokenizer import BaseTokenizer
+from fed_rag.data_structures import Context, Prompt, Query
 
 DEFAULT_PROMPT_TEMPLATE = """
 You are a helpful assistant. Given the user's query, provide a succinct
@@ -32,13 +33,16 @@ class BaseGenerator(BaseModel, ABC):
 
     @abstractmethod
     def generate(
-        self, query: str | list[str], context: str, **kwargs: dict
+        self,
+        query: str | list[str] | Query | list[Query],
+        context: str | list[str] | Context | list[Context],
+        **kwargs: dict,
     ) -> str | list[str]:
         """Generate an output from a given query and context."""
 
     @abstractmethod
     def complete(
-        self, prompt: str | list[str], **kwargs: dict
+        self, prompt: str | list[str] | Prompt | list[Prompt], **kwargs: dict
     ) -> str | list[str]:
         """Completion interface for generator LLMs."""
 
@@ -54,7 +58,7 @@ class BaseGenerator(BaseModel, ABC):
 
     @abstractmethod
     def compute_target_sequence_proba(
-        self, prompt: str, target: str
+        self, prompt: str | Prompt, target: str
     ) -> torch.Tensor:
         """Compute P(target | prompt).
 

--- a/src/fed_rag/base/generator_mixins/__init__.py
+++ b/src/fed_rag/base/generator_mixins/__init__.py
@@ -1,0 +1,3 @@
+from .image import GeneratorHasImageModality, ImageModalityMixin
+
+__all__ = ["GeneratorHasImageModality", "ImageModalityMixin"]

--- a/src/fed_rag/base/generator_mixins/image.py
+++ b/src/fed_rag/base/generator_mixins/image.py
@@ -1,0 +1,31 @@
+"""Generator Mixins."""
+
+from typing import Protocol, runtime_checkable
+
+from fed_rag.exceptions.retriever import RetrieverError
+
+
+@runtime_checkable
+class HasImageModality(Protocol):
+    """Associated protocol for `ImageModalityMixin`."""
+
+    __supports_images__: bool = True
+
+
+class ImageModalityMixin:
+    """Image Modality Mixin.
+
+    Meant to be mixed with a `BaseGenerator` to indicate the ability to accept
+    image inputs.
+    """
+
+    __supports_images__ = True
+
+    def __init_subclass__(cls) -> None:
+        """Validate this is mixed with `BaseGenerator`."""
+        super().__init_subclass__()
+
+        if "BaseGenerator" not in [t.__name__ for t in cls.__mro__]:
+            raise RetrieverError(
+                "`ImageModalityMixin` must be mixed with `BaseGenerator`."
+            )

--- a/src/fed_rag/base/generator_mixins/image.py
+++ b/src/fed_rag/base/generator_mixins/image.py
@@ -2,11 +2,11 @@
 
 from typing import Protocol, runtime_checkable
 
-from fed_rag.exceptions.retriever import RetrieverError
+from fed_rag.exceptions.generator import GeneratorError
 
 
 @runtime_checkable
-class HasImageModality(Protocol):
+class GeneratorHasImageModality(Protocol):
     """Associated protocol for `ImageModalityMixin`."""
 
     __supports_images__: bool = True
@@ -26,6 +26,6 @@ class ImageModalityMixin:
         super().__init_subclass__()
 
         if "BaseGenerator" not in [t.__name__ for t in cls.__mro__]:
-            raise RetrieverError(
+            raise GeneratorError(
                 "`ImageModalityMixin` must be mixed with `BaseGenerator`."
             )

--- a/src/fed_rag/data_structures/__init__.py
+++ b/src/fed_rag/data_structures/__init__.py
@@ -11,6 +11,7 @@ from .evals import (
     BenchmarkExample,
     BenchmarkResult,
 )
+from .generator import Context, Prompt, Query
 from .knowledge_node import KnowledgeNode, NodeContent, NodeType
 from .rag import RAGConfig, RAGResponse, SourceNode
 from .results import TestResult, TrainResult
@@ -24,6 +25,10 @@ __all__ = [
     "BenchmarkExample",
     "BenchmarkResult",
     "BenchmarkEvaluatedExample",
+    # generator
+    "Query",
+    "Context",
+    "Prompt",
     # results
     "TrainResult",
     "TestResult",

--- a/src/fed_rag/data_structures/generator.py
+++ b/src/fed_rag/data_structures/generator.py
@@ -1,0 +1,59 @@
+"""Auxiliary types for RAG System"""
+
+from PIL import Image
+from pydantic import BaseModel, ConfigDict
+
+
+class _MultiModalDataContainer(BaseModel):
+    """A multi-modal data container.
+
+    This class represents a multimodal representation of a RAG query.
+
+    Attributes:
+        text: Text content of query.
+        images: Images content of query.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    text: str
+    images: list[Image.Image] | None = None
+
+
+class Query(_MultiModalDataContainer):
+    """Query data structure.
+
+    This class represents a multimodal representation of a RAG query.
+
+    Attributes:
+        text: Text content of query.
+        images: Images content of query.
+    """
+
+    pass
+
+
+class Context(_MultiModalDataContainer):
+    """Context data structure.
+
+    This class represents a multimodal representation of RAG context.
+
+    Attributes:
+        text: Text content of query.
+        images: Images content of query.
+    """
+
+    pass
+
+
+class Prompt(_MultiModalDataContainer):
+    """Prompt data structure.
+
+    This class represents a multimodal representation of a prompt given to a
+    multi-modal LLM.
+
+    Attributes:
+        text: Text content of query.
+        images: Images content of query.
+    """
+
+    pass

--- a/src/fed_rag/generators/huggingface/mixin.py
+++ b/src/fed_rag/generators/huggingface/mixin.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from transformers import PreTrainedModel
     from transformers.generation.utils import GenerationConfig
 
+from fed_rag.data_structures import Context, Prompt, Query
 from fed_rag.tokenizers.hf_pretrained_tokenizer import HFPretrainedTokenizer
 
 
@@ -29,7 +30,9 @@ class HFGeneratorProtocol(Protocol):
 class HuggingFaceGeneratorMixin:
     # complete
     def complete(
-        self: HFGeneratorProtocol, prompt: str | list[str], **kwargs: Any
+        self: HFGeneratorProtocol,
+        prompt: str | list[str] | Prompt | list[Prompt],
+        **kwargs: Any,
     ) -> str | list[str]:
         # encode query
         tokenizer_result = self.tokenizer.unwrapped(
@@ -58,8 +61,8 @@ class HuggingFaceGeneratorMixin:
     # generate
     def generate(
         self: HFGeneratorProtocol,
-        query: str | list[str],
-        context: str | list[str],
+        query: str | list[str] | Query | list[Query],
+        context: str | list[str] | Context | list[Context],
         **kwargs: Any,
     ) -> str | list[str]:
         if isinstance(query, str):
@@ -75,13 +78,13 @@ class HuggingFaceGeneratorMixin:
         return self.complete(prompt=formatted_queries, **kwargs)
 
     def compute_target_sequence_proba(
-        self: HFGeneratorProtocol, prompt: str, target: str
+        self: HFGeneratorProtocol, prompt: str | Prompt, target: str
     ) -> torch.Tensor:
         """Computes the target sequence probability given the prompt.
 
         Args:
             generator (BaseGenerator): The generator LLM
-            prompt (str): The input i.e. conditional prompt sequence
+            prompt (str | Prompt): The input i.e. conditional prompt sequence
             target (str): The target sequence
 
         Returns:

--- a/tests/generators/mixins/test_image_mixin.py
+++ b/tests/generators/mixins/test_image_mixin.py
@@ -1,0 +1,32 @@
+import pytest
+from pydantic import BaseModel
+
+from fed_rag.base.generator import BaseGenerator
+from fed_rag.base.generator_mixins import (
+    GeneratorHasImageModality,
+    ImageModalityMixin,
+)
+from fed_rag.exceptions.generator import GeneratorError
+
+from ..conftest import MockGenerator
+
+
+class MockMMGenerator(ImageModalityMixin, MockGenerator):
+    pass
+
+
+def test_mixin() -> None:
+    mixed_generator = MockMMGenerator()
+
+    assert isinstance(mixed_generator, GeneratorHasImageModality)
+    assert isinstance(mixed_generator, BaseGenerator)
+
+
+def test_mixin_fails_validation() -> None:
+    with pytest.raises(
+        GeneratorError,
+        match="`ImageModalityMixin` must be mixed with `BaseGenerator`.",
+    ):
+
+        class InvalidMockMMGenerator(ImageModalityMixin, BaseModel):
+            pass


### PR DESCRIPTION
# FedRAG Pull Request Template

Thanks for contributing to FedRAG!
Please fill out the sections below to help us review your PR efficiently.

## Summary

What does this PR do? Please provide a brief summary of the changes introduced.

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

## Description
This PR expands `BaseGenerator` to allow for multimodal interactions (image, text) -> text. This is accomplished by the introduction of a new data structure that is a container for the various data types. NOTE: only image and text are supported, but this structure should make it easy to add new data/media types in the future.

Similar to the expansion of `BaseRetriever` we also include `mixins` and associated protocols to have a consistent interface for checking if retrievers/generators have multimodal capabilities.

## Testing

Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.

- [x] Unit tests added or updated
- [x] All tests pass locally (`make test`)
- [x] Code coverage maintained or improved
