### PR TITLE
Add Unsloth Fast Multimodal Model Generator (FastModel Integration)

### DIFF
--- a/docs/api_reference/generators/unsloth.md
+++ b/docs/api_reference/generators/unsloth.md
@@ -4,3 +4,8 @@
     options:
       members:
         - UnslothFastModelGenerator
+
+::: src.fed_rag.generators.unsloth.unsloth_fast_multimodal_model
+    options:
+      members:
+        - UnslothFastMultimodalModelGenerator

--- a/src/fed_rag/generators/unsloth/__init__.py
+++ b/src/fed_rag/generators/unsloth/__init__.py
@@ -1,3 +1,4 @@
 from .unsloth_fast_model import UnslothFastModelGenerator
+from .unsloth_fast_multimodal_model import UnslothFastMultimodalModelGenerator
 
-__all__ = ["UnslothFastModelGenerator"]
+__all__ = ["UnslothFastModelGenerator", "UnslothFastMultimodalModelGenerator"]

--- a/src/fed_rag/generators/unsloth/unsloth_fast_multimodal_model.py
+++ b/src/fed_rag/generators/unsloth/unsloth_fast_multimodal_model.py
@@ -1,0 +1,269 @@
+"""Unsloth Fast Multimodal Model Generator (aligned with HF style)"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from pydantic import ConfigDict, Field, PrivateAttr, model_validator
+
+if TYPE_CHECKING:
+    from unsloth import FastModel
+
+from fed_rag.base.generator import BaseGenerator
+from fed_rag.base.generator_mixins.audio import AudioModalityMixin
+from fed_rag.base.generator_mixins.image import ImageModalityMixin
+from fed_rag.base.generator_mixins.video import VideoModalityMixin
+from fed_rag.data_structures.rag import Context, Prompt, Query
+from fed_rag.exceptions.generator import GeneratorError
+
+from .mixin import UnslothGeneratorMixin
+from .utils import check_unsloth_installed
+
+
+class UnslothFastMultimodalModelGenerator(
+    ImageModalityMixin,
+    AudioModalityMixin,
+    VideoModalityMixin,
+    UnslothGeneratorMixin,
+    BaseGenerator,
+):
+    model_config = ConfigDict(
+        protected_namespaces=("pydantic_model_",), arbitrary_types_allowed=True
+    )
+    model_name: str = Field(description="Unsloth model name or path.")
+    modality_types: set[str] = Field(
+        default_factory=lambda: {"text", "image", "audio", "video"}
+    )
+    generation_config: Optional[Any] = Field(default=None)
+    load_model_kwargs: dict = Field(default_factory=dict)
+    prompt_template_init: str | None = Field(default=None)
+    load_model_at_init: bool = Field(default=True)
+
+    _model: Optional["FastModel"] = PrivateAttr(default=None)
+    _processor: Any = PrivateAttr(default=None)
+    _prompt_template: str = PrivateAttr(default="")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_unsloth_available(cls, data: Any) -> Any:
+        check_unsloth_installed(cls.__name__)
+        return data
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._prompt_template = self.prompt_template_init or ""
+        self._model = None
+        self._processor = None
+        if self.load_model_at_init:
+            self._model, self._processor = self._load_model_from_unsloth()
+
+    def _load_model_from_unsloth(self) -> tuple[Any, Any]:
+        from unsloth import FastModel
+
+        model, processor = FastModel.from_pretrained(
+            model_name=self.model_name,
+            **self.load_model_kwargs,
+        )
+        return model, processor
+
+    def to_query(self, q: str | Query | Prompt) -> Query:
+        if isinstance(q, Query):
+            return q
+        if isinstance(q, Prompt):
+            return Query(
+                text=q.text,
+                images=getattr(q, "images", None),
+                audios=getattr(q, "audios", None),
+                videos=getattr(q, "videos", None),
+            )
+        return Query(text=str(q))
+
+    def to_context(self, c: str | Context | None) -> Context | None:
+        if c is None or isinstance(c, Context):
+            return c
+        return Context(text=str(c))
+
+    def _pack_messages(
+        self,
+        query: str | Query | list[str] | list[Query],
+        context: str | Context | list[str] | list[Context] | None = None,
+    ) -> list[dict[str, Any]]:
+        queries = (
+            [query] if not isinstance(query, list) else query  # type: ignore[arg-type]
+        )
+        queries = [self.to_query(q) for q in queries]
+
+        if isinstance(context, list):
+            contexts = [self.to_context(c) for c in context]
+            if len(contexts) != len(queries):
+                raise GeneratorError(
+                    "Batch mode requires query and context to be the same length"
+                )
+        else:
+            contexts = [self.to_context(context)] * len(queries)
+
+        messages: list[dict[str, Any]] = []
+        for q, ctx in zip(queries, contexts):
+            content: list[dict[str, Any]] = []
+            if ctx is not None:
+                if getattr(ctx, "text", None):
+                    content.append({"type": "text", "text": ctx.text})
+                for im in getattr(ctx, "images", []) or []:
+                    from PIL import Image as PILImage
+
+                    if isinstance(im, np.ndarray):
+                        im = PILImage.fromarray(im)
+                    content.append({"type": "image", "image": im})
+                for au in getattr(ctx, "audios", []) or []:
+                    content.append({"type": "audio", "audio": au})
+                for vid in getattr(ctx, "videos", []) or []:
+                    content.append({"type": "video", "video": vid})
+            for im in getattr(q, "images", []) or []:
+                from PIL import Image as PILImage
+
+                if isinstance(im, np.ndarray):
+                    im = PILImage.fromarray(im)
+                content.append({"type": "image", "image": im})
+            for au in getattr(q, "audios", []) or []:
+                content.append({"type": "audio", "audio": au})
+            for vid in getattr(q, "videos", []) or []:
+                content.append({"type": "video", "video": vid})
+            if getattr(q, "text", None):
+                content.append({"type": "text", "text": q.text})
+
+            messages.append({"role": "user", "content": content})
+        return messages
+
+    def generate(
+        self,
+        query: str | Query | list[str] | list[Query],
+        context: str | Context | list[str] | list[Context] | None = None,
+        **gen_kwargs: Any,
+    ) -> str | list[str]:
+        max_new_tokens = gen_kwargs.pop("max_new_tokens", 256)
+        add_generation_prompt = gen_kwargs.pop("add_generation_prompt", True)
+        messages = self._pack_messages(query, context)
+        inputs = self._processor.apply_chat_template(
+            messages,
+            add_generation_prompt=add_generation_prompt,
+            tokenize=True,
+            return_tensors="pt",
+            return_dict=True,
+        )
+        input_len = inputs["input_ids"].shape[-1]
+        with torch.inference_mode():
+            generation = self.model.generate(
+                **inputs, max_new_tokens=max_new_tokens, **gen_kwargs
+            )
+            generation = generation[:, input_len:]
+        decoded: list[str] = self._processor.batch_decode(
+            generation, skip_special_tokens=True
+        )
+        if not isinstance(query, list):
+            if not decoded or not isinstance(decoded[0], str):
+                raise GeneratorError(
+                    "batch_decode did not return valid output"
+                )
+            return decoded[0]
+        return decoded
+
+    def complete(
+        self, prompt: Prompt | list[Prompt] | str | list[str], **kwargs: Any
+    ) -> str | list[str]:
+        if isinstance(prompt, list):
+            queries = [self.to_query(p) for p in prompt]
+        else:
+            queries = self.to_query(prompt)
+        return self.generate(query=queries, context=None, **kwargs)
+
+    def compute_target_sequence_proba(
+        self,
+        prompt: Prompt | str,
+        target: str,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        from PIL import Image as PILImage
+
+        q = self.to_query(prompt)
+        base_text = getattr(q, "text", "") or ""
+        full_text = base_text + target
+        content: list[dict[str, Any]] = []
+
+        for im in getattr(q, "images", []) or []:
+            if isinstance(im, np.ndarray):
+                im = PILImage.fromarray(im)
+            content.append({"type": "image", "image": im})
+        for au in getattr(q, "audios", []) or []:
+            content.append({"type": "audio", "audio": au})
+        for vid in getattr(q, "videos", []) or []:
+            content.append({"type": "video", "video": vid})
+        if getattr(q, "text", None):
+            content.append({"type": "text", "text": q.text})
+
+        content.append({"type": "text", "text": full_text})
+        messages = [{"role": "user", "content": content}]
+        inputs = self._processor.apply_chat_template(
+            messages,
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        input_ids = inputs["input_ids"]
+        prompt_inputs = self._processor.apply_chat_template(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": base_text}],
+                }
+            ],
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        prompt_len = prompt_inputs["input_ids"].shape[-1]
+        with torch.no_grad():
+            outputs = self.model(**inputs)
+        if not hasattr(outputs, "logits") or outputs.logits is None:
+            raise GeneratorError(
+                "Underlying model does not expose logits; cannot compute probabilities."
+            )
+        logits = outputs.logits
+        target_ids = input_ids[0][prompt_len:]
+        target_logits = logits[0, prompt_len - 1 : -1, :]
+        log_probs = [
+            F.log_softmax(target_logits[i], dim=-1)[tid].item()
+            for i, tid in enumerate(target_ids)
+        ]
+        return torch.exp(torch.tensor(sum(log_probs)))
+
+    @property
+    def model(self) -> "FastModel":
+        if self._model is None:
+            self._model, self._processor = self._load_model_from_unsloth()
+        return self._model
+
+    @property
+    def tokenizer(self) -> Any:
+        if hasattr(self._processor, "tokenizer"):
+            return self._processor.tokenizer
+        if callable(getattr(self._processor, "encode", None)):
+            return self._processor
+        raise AttributeError(
+            f"{self.__class__.__name__}: This processor does not have a `.tokenizer` attribute. "
+            "For some multimodal models, please use `.processor` directly."
+        )
+
+    @property
+    def processor(self) -> Any:
+        return self._processor
+
+    @property
+    def prompt_template(self) -> str:
+        return self._prompt_template
+
+    @prompt_template.setter
+    def prompt_template(self, value: str) -> None:
+        self._prompt_template = value

--- a/src/fed_rag/generators/unsloth/unsloth_fast_multimodal_model.py
+++ b/src/fed_rag/generators/unsloth/unsloth_fast_multimodal_model.py
@@ -151,6 +151,14 @@ class UnslothFastMultimodalModelGenerator(
             return_tensors="pt",
             return_dict=True,
         )
+
+        # Unsloth: must manually move all input tensors to the model device.
+        model_device = next(self.model.parameters()).device
+        inputs = {
+            k: v.to(model_device) if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+
         input_len = inputs["input_ids"].shape[-1]
         with torch.inference_mode():
             generation = self.model.generate(
@@ -210,6 +218,12 @@ class UnslothFastMultimodalModelGenerator(
             return_dict=True,
             return_tensors="pt",
         )
+        model_device = next(self.model.parameters()).device
+        inputs = {
+            k: v.to(model_device) if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+
         input_ids = inputs["input_ids"]
         prompt_inputs = self._processor.apply_chat_template(
             [

--- a/tests/generators/test_unsloth_fast_multimodal_model.py
+++ b/tests/generators/test_unsloth_fast_multimodal_model.py
@@ -1,0 +1,513 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from fed_rag.data_structures.rag import Context, Prompt, Query
+from fed_rag.exceptions.generator import GeneratorError
+from fed_rag.generators.unsloth.unsloth_fast_multimodal_model import (
+    UnslothFastMultimodalModelGenerator,
+)
+
+
+def dummy_image() -> Image.Image:
+    return Image.fromarray((np.random.rand(32, 32, 3) * 255).astype("uint8"))
+
+
+def dummy_audio() -> np.ndarray:
+    return (np.random.rand(16000) * 2 - 1).astype("float32")
+
+
+def dummy_video() -> np.ndarray:
+    return (np.random.rand(1, 32, 32, 3) * 255).astype("uint8")
+
+
+@patch("unsloth.FastModel.from_pretrained")
+def test_unsloth_multimodal_generator_init(mock_from_pretrained):
+    mock_model = MagicMock()
+    mock_processor = MagicMock()
+    mock_from_pretrained.return_value = (mock_model, mock_processor)
+
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+
+    assert generator.model_name == "fake-mm-model"
+    assert generator._model is not None
+    assert generator._processor is not None
+    assert isinstance(generator, UnslothFastMultimodalModelGenerator)
+
+
+def test_pack_messages_batch_mismatch_raises():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    generator.to_query.side_effect = lambda x: (
+        x
+        if isinstance(x, Query)
+        else Query(text=x, images=[], audios=[], videos=[])
+    )
+    generator.to_context.side_effect = lambda x: (
+        x
+        if isinstance(x, Context)
+        else Context(text=x, images=[], audios=[], videos=[])
+    )
+    generator._pack_messages = (
+        UnslothFastMultimodalModelGenerator._pack_messages.__get__(generator)
+    )
+
+    img = dummy_image()
+    audio = dummy_audio()
+    video = dummy_video()
+    qs = [
+        Query(text="q1", images=[img], audios=[audio], videos=[video]),
+        Query(text="q2", images=[img], audios=[audio], videos=[video]),
+    ]
+    c = Context(text="ctx1", images=[img], audios=[audio], videos=[video])
+    with pytest.raises(
+        GeneratorError,
+        match="Batch mode requires query and context to be the same length",
+    ):
+        generator._pack_messages(qs, context=[c])
+
+
+def test_pack_messages_single_and_batch():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    generator.to_query.side_effect = lambda x: (
+        x
+        if isinstance(x, Query)
+        else Query(text=x, images=[], audios=[], videos=[])
+    )
+    generator.to_context.side_effect = lambda x: (
+        x
+        if isinstance(x, Context)
+        else Context(text=x, images=[], audios=[], videos=[])
+    )
+    generator._pack_messages = (
+        UnslothFastMultimodalModelGenerator._pack_messages.__get__(generator)
+    )
+
+    img = dummy_image()
+    audio = dummy_audio()
+    video = dummy_video()
+    q = Query(text="hello world", images=[img], audios=[audio], videos=[video])
+    c = Context(text="ctx", images=[img], audios=[audio], videos=[video])
+    messages = generator._pack_messages(q, context=c)
+    assert isinstance(messages, list)
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert {"type": "text", "text": "ctx"} in content
+    assert {"type": "image", "image": img} in content
+    assert any(
+        x["type"] == "audio" and np.allclose(x["audio"], audio)
+        for x in content
+    )
+    assert {"type": "video", "video": video} in content
+    assert {"type": "text", "text": "hello world"} in content
+
+    qs = [
+        Query(text="q1", images=[img], audios=[audio], videos=[video]),
+        Query(text="q2", images=[img], audios=[audio], videos=[video]),
+    ]
+    cs = [
+        Context(text="ctx1", images=[img], audios=[audio], videos=[video]),
+        Context(text="ctx2", images=[img], audios=[audio], videos=[video]),
+    ]
+
+    messages_batch = generator._pack_messages(qs, context=cs)
+    assert len(messages_batch) == 2
+    for msg, qobj in zip(messages_batch, qs):
+        assert {"type": "text", "text": qobj.text} in msg["content"]
+
+
+@patch("unsloth.FastModel.from_pretrained")
+def test_generate_returns_batch(mock_from_pretrained):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.return_value = {
+        "input_ids": torch.ones((2, 8), dtype=torch.long)
+    }
+    mock_model.generate.return_value = torch.ones((2, 10), dtype=torch.long)
+    mock_proc.batch_decode.return_value = ["resp1", "resp2"]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+    img = dummy_image()
+    audio = dummy_audio()
+    video = dummy_video()
+    qs = [
+        Query(
+            text="what do you see?",
+            images=[img],
+            audios=[audio],
+            videos=[video],
+        ),
+        Query(
+            text="what do you see next?",
+            images=[img],
+            audios=[audio],
+            videos=[video],
+        ),
+    ]
+    cs = [
+        Context(text="", images=[img], audios=[audio], videos=[video]),
+        Context(text="", images=[img], audios=[audio], videos=[video]),
+    ]
+    out = generator.generate(query=qs, context=cs)
+    assert isinstance(out, list)
+    assert out == ["resp1", "resp2"]
+
+
+def test_to_query_and_to_context_types():
+    gen = UnslothFastMultimodalModelGenerator.__new__(
+        UnslothFastMultimodalModelGenerator
+    )
+    assert gen.to_query("abc").text == "abc"
+    prompt = Prompt(text="prompt")
+    q = gen.to_query(prompt)
+    assert isinstance(q, Query) and q.text == "prompt"
+    real_q = Query(text="qtext")
+    assert gen.to_query(real_q) is real_q
+    assert gen.to_context("ctx").text == "ctx"
+    ctx = Context(text="ctx_obj")
+    assert gen.to_context(ctx) is ctx
+
+
+@patch("torch.nn.functional.log_softmax")
+@patch("unsloth.FastModel.from_pretrained")
+def test_compute_target_sequence_proba_with_modalities(
+    mock_from_pretrained,
+    mock_log_softmax,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.side_effect = [
+        {"input_ids": torch.arange(10).unsqueeze(0)},
+        {"input_ids": torch.arange(5).unsqueeze(0)},
+    ]
+    logits = torch.randn(1, 10, 100)
+    mock_model.return_value = MagicMock(logits=logits)
+    mock_proc.batch_decode.return_value = ["dummy"]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    mock_log_softmax.return_value = torch.zeros(100)
+
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+    img_np = (np.random.rand(32, 32, 3) * 255).astype("uint8")
+    audio_np = (np.random.rand(16000) * 2 - 1).astype("float32")
+    video_np = (np.random.rand(1, 32, 32, 3) * 255).astype("uint8")
+
+    q = Query(
+        text="context" + "what is this?",
+        images=[dummy_image(), Image.fromarray(img_np)],
+        audios=[audio_np, audio_np],
+        videos=[video_np, video_np],
+    )
+    prob = generator.compute_target_sequence_proba(
+        prompt=q,
+        target="test",
+    )
+    assert isinstance(prob, torch.Tensor)
+
+
+def test_pack_messages_with_ndarray_inputs():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    generator.to_query.side_effect = lambda x: (
+        x
+        if isinstance(x, Query)
+        else Query(text=x, images=[], audios=[], videos=[])
+    )
+    generator.to_context.side_effect = lambda x: (
+        x
+        if isinstance(x, Context)
+        else Context(text=x, images=[], audios=[], videos=[])
+    )
+    generator._pack_messages = (
+        UnslothFastMultimodalModelGenerator._pack_messages.__get__(generator)
+    )
+
+    img_np = (np.random.rand(32, 32, 3) * 255).astype("uint8")
+    audio_np = dummy_audio()
+    video_np = dummy_video()
+    q = Query(
+        text="hello ndarray",
+        images=[dummy_image()],
+        audios=[audio_np],
+        videos=[video_np],
+    )
+    c = Context(
+        text="ctx ndarray",
+        images=[dummy_image()],
+        audios=[audio_np],
+        videos=[video_np],
+    )
+    q.images = [img_np]
+    c.images = [img_np]
+
+    messages = generator._pack_messages(q, context=c)
+    imgs = [x["image"] for x in messages[0]["content"] if x["type"] == "image"]
+    assert all(isinstance(im, Image.Image) for im in imgs)
+    assert isinstance(messages, list)
+    assert messages[0]["role"] == "user"
+    content = messages[0]["content"]
+    assert any(x["type"] == "image" for x in content)
+    assert any(x["type"] == "audio" for x in content)
+    assert any(x["type"] == "video" for x in content)
+
+
+@patch("unsloth.FastModel.from_pretrained")
+def test_generate_and_complete(mock_from_pretrained):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.return_value = {
+        "input_ids": torch.ones((1, 8), dtype=torch.long)
+    }
+    mock_model.generate.return_value = torch.ones((1, 10), dtype=torch.long)
+    mock_proc.batch_decode.return_value = ["a test response"]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+
+    img = dummy_image()
+    audio = dummy_audio()
+    video = dummy_video()
+    q = Query(
+        text="what do you see?", images=[img], audios=[audio], videos=[video]
+    )
+    c = Context(text="", images=[img], audios=[audio], videos=[video])
+
+    out = generator.generate(
+        query=q,
+        context=c,
+        max_new_tokens=4,
+    )
+    assert isinstance(out, str)
+    assert out == "a test response"
+    p = Prompt(text="another prompt")
+    out2 = generator.complete(prompt=p)
+    assert out2 == "a test response"
+
+
+def test_prompt_template_setter():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    generator._prompt_template = ""
+    UnslothFastMultimodalModelGenerator.prompt_template.fset(
+        generator, "abc {context}"
+    )
+    assert generator._prompt_template == "abc {context}"
+
+
+@patch("torch.nn.functional.log_softmax")
+@patch("unsloth.FastModel.from_pretrained")
+def test_compute_target_sequence_proba(
+    mock_from_pretrained,
+    mock_log_softmax,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.side_effect = [
+        {"input_ids": torch.arange(10).unsqueeze(0)},
+        {"input_ids": torch.arange(5).unsqueeze(0)},
+    ]
+    logits = torch.randn(1, 10, 100)
+    mock_model.return_value = MagicMock(logits=logits)
+    mock_log_softmax.return_value = torch.zeros(100)
+    mock_proc.batch_decode.return_value = ["dummy"]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+
+    q = Query(
+        text="context" + "what is this?",  # concatenate
+        images=[],
+        audios=[],
+        videos=[],
+    )
+    prob = generator.compute_target_sequence_proba(
+        prompt=q,
+        target="test",
+    )
+    assert isinstance(prob, torch.Tensor)
+
+
+def test_model_property_and_tokenizer():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    fake_model = MagicMock()
+    fake_processor = MagicMock()
+    fake_tokenizer = MagicMock()
+    generator._model = fake_model
+    generator._processor = fake_processor
+    fake_processor.tokenizer = fake_tokenizer
+
+    assert (
+        UnslothFastMultimodalModelGenerator.model.fget(generator) is fake_model
+    )
+    assert (
+        UnslothFastMultimodalModelGenerator.tokenizer.fget(generator)
+        is fake_tokenizer
+    )
+    assert (
+        UnslothFastMultimodalModelGenerator.processor.fget(generator)
+        is fake_processor
+    )
+
+
+def test_tokenizer_returns_processor_tokenizer():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    fake_processor = MagicMock()
+    fake_tokenizer = MagicMock()
+    fake_processor.tokenizer = fake_tokenizer
+    generator._processor = fake_processor
+    assert (
+        UnslothFastMultimodalModelGenerator.tokenizer.fget(generator)
+        is fake_tokenizer
+    )
+
+
+def test_tokenizer_returns_processor_if_encode():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    fake_processor = MagicMock()
+    if hasattr(fake_processor, "tokenizer"):
+        del fake_processor.tokenizer
+    fake_processor.encode = MagicMock()
+    generator._processor = fake_processor
+    assert (
+        UnslothFastMultimodalModelGenerator.tokenizer.fget(generator)
+        is fake_processor
+    )
+
+
+def test_tokenizer_raises_if_neither_tokenizer_nor_encode():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    fake_processor = MagicMock()
+    if hasattr(fake_processor, "tokenizer"):
+        del fake_processor.tokenizer
+    if hasattr(fake_processor, "encode"):
+        del fake_processor.encode
+    generator._processor = fake_processor
+    with pytest.raises(
+        AttributeError, match="does not have a `.tokenizer` attribute"
+    ):
+        UnslothFastMultimodalModelGenerator.tokenizer.fget(generator)
+
+
+def test_processor_property():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    fake_processor = MagicMock()
+    generator._processor = fake_processor
+    assert (
+        UnslothFastMultimodalModelGenerator.processor.fget(generator)
+        is fake_processor
+    )
+
+
+def test_prompt_template_property():
+    generator = MagicMock(spec=UnslothFastMultimodalModelGenerator)
+    generator._prompt_template = "prompt!"
+    assert (
+        UnslothFastMultimodalModelGenerator.prompt_template.fget(generator)
+        == "prompt!"
+    )
+    UnslothFastMultimodalModelGenerator.prompt_template.fset(
+        generator, "new template"
+    )
+    assert generator._prompt_template == "new template"
+
+
+@patch("torch.nn.functional.log_softmax")
+@patch("unsloth.FastModel.from_pretrained")
+def test_compute_target_sequence_proba_ndarray_image(
+    mock_from_pretrained,
+    mock_log_softmax,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.side_effect = [
+        {"input_ids": torch.arange(10).unsqueeze(0)},
+        {"input_ids": torch.arange(5).unsqueeze(0)},
+    ]
+    logits = torch.randn(1, 10, 100)
+    mock_model.return_value = MagicMock(logits=logits)
+    mock_log_softmax.return_value = torch.zeros(100)
+    mock_proc.batch_decode.return_value = ["dummy"]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+    img_np = (np.random.rand(32, 32, 3) * 255).astype("uint8")
+    img = Image.fromarray(img_np)
+    q = Query(
+        text="what is this?",
+        images=[img, Image.fromarray(img_np)],
+        audios=None,
+        videos=None,
+    )
+    prob = generator.compute_target_sequence_proba(
+        prompt=q,
+        target="test",
+    )
+    assert isinstance(prob, torch.Tensor)
+
+
+@patch("unsloth.FastModel.from_pretrained")
+def test_generate_raises_generatorerror_on_bad_batch_decode(
+    mock_from_pretrained,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.return_value = {
+        "input_ids": torch.ones((1, 8), dtype=torch.long)
+    }
+    mock_model.generate.return_value = torch.ones((1, 10), dtype=torch.long)
+    mock_proc.batch_decode.return_value = [1234]
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+    q = Query(text="what do you see?", images=None, audios=None, videos=None)
+    c = Context(text="ctx", images=[], audios=[], videos=[])
+    with pytest.raises(
+        GeneratorError, match="batch_decode did not return valid output"
+    ):
+        generator.generate(
+            query=q,
+            context=c,
+        )
+
+
+@patch("torch.nn.functional.log_softmax")
+@patch("unsloth.FastModel.from_pretrained")
+@pytest.mark.parametrize("model_output", [object(), MagicMock(logits=None)])
+def test_compute_target_sequence_proba_raises_on_missing_logits(
+    mock_from_pretrained,
+    mock_log_softmax,
+    model_output,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_proc.apply_chat_template.side_effect = [
+        {"input_ids": torch.arange(10).unsqueeze(0)},
+        {"input_ids": torch.arange(5).unsqueeze(0)},
+    ]
+    mock_model.return_value = model_output
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    generator = UnslothFastMultimodalModelGenerator(model_name="fake-mm-model")
+    img = dummy_image()
+    q = Query(text="what is this?", images=[img], audios=[], videos=[])
+    with pytest.raises(
+        GeneratorError,
+        match="Underlying model does not expose logits; cannot compute probabilities.",
+    ):
+        generator.compute_target_sequence_proba(
+            prompt=q,
+            target="test",
+        )
+
+
+@patch("unsloth.FastModel.from_pretrained")
+def test_lazy_loading_model(
+    mock_from_pretrained,
+):
+    mock_proc = MagicMock()
+    mock_model = MagicMock()
+    mock_from_pretrained.return_value = (mock_model, mock_proc)
+    generator = UnslothFastMultimodalModelGenerator(
+        model_name="fake-mm-model", load_model_at_init=False
+    )
+    assert generator._model is None
+    _ = generator.model
+    assert generator._model is not None
+    _ = generator.model
+    assert generator._model is not None


### PR DESCRIPTION
## Summary

**What does this PR do?**

This PR introduces the `UnslothFastMultimodalModelGenerator` class, adding support for Unsloth’s FastModel-based multimodal generation in FedRAG.  
It also adds an accompanying test script for this new generator.

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Code quality / linting
- [ ] Other (please describe):

---

## Description

- Implements `UnslothFastMultimodalModelGenerator` in `unsloth_multimodal_model.py`.
- Provides a drop-in multimodal generator using Unsloth’s FastModel for improved efficiency, with support for text, image, audio, and video modalities.
- Mirrors the interface and much of the logic of `hf_multimodal_model.py` but with a few backend differences.
- **Key implementation differences from `hf_multimodal_model.py`:**
  - Uses `FastModel` from the `unsloth` library instead of HuggingFace’s `PreTrainedModel`.
  - **Device management:** Unlike HuggingFace models, FastModel does not always auto-move tensors to the model device. Therefore, all tensor inputs are **manually moved** to the model device before inference in both `generate()` and `compute_target_sequence_proba()`:
    ```python
    model_device = next(self.model.parameters()).device
    inputs = {k: v.to(model_device) if isinstance(v, torch.Tensor) else v for k, v in inputs.items()}
    ```
  - Slightly different logic for processor/tokenizer access to align with Unsloth’s patched processor.

---

## Testing

**Describe how you tested your changes. Include the steps to reproduce, commands run, and any relevant outputs.**

- [x] Unit tests added and updated in `test_unsloth_multimodal_model.py`.
  - Tested text-only generation: ensures string output, matches known answers.
  - Tested image+text (multimodal) generation: ensures successful run and output type.
  - Tested device placement: asserts tensors and model are on correct CUDA device.
  - Tested probability computation (`compute_target_sequence_proba`).
- [x] All tests pass locally (`make test`).
- [x] Manually verified model outputs on sample queries.
- [x] Verified integration with `RAGSystem` and compatibility with other FedRAG modules.

---

## Checklist

Before submitting your PR, please check off the following:

- [x] My code follows the existing style and conventions
- [x] I’ve run linting (`make lint`)
- [x] I’ve added/updated relevant documentation
- [x] I’ve added/updated tests as needed
- [ ] I’ve verified integration with existing tools (HuggingFace, LlamaIndex, LangChain, etc. if applicable)
- [ ] I’ve added an entry to the CHANGELOG.md (if applicable)

---

## Related Issues or PRs

If this PR addresses or relates to existing issues or pull requests, link them here:

- Closes #   <!-- Fill in with issue number if exists -->
- Related to #   <!-- Fill in if related to other PRs/issues -->

---

## Example usage

```python
import unsloth
from unsloth import FastModel

from fed_rag.generators.unsloth import UnslothFastMultimodalModelGenerator
generator = UnslothFastMultimodalModelGenerator(
    model_name="unsloth/gemma-3n-E2B-it",
    load_model_kwargs={
       "load_in_4bit": True,
        "device_map": device,  # Explicit device
        "trust_remote_code": True, 
    },
    load_model_at_init=True,
)

response = generator.generate("Who is James Cook?")
print(response)
